### PR TITLE
Optimizar búsqueda por prefijo de código postal

### DIFF
--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -44,9 +45,11 @@ public class ZipCodeService {
 
     private static final java.util.regex.Pattern ZIP_CODE_PATTERN =
         java.util.regex.Pattern.compile("^\\d{5}$");
+    private static final java.util.regex.Pattern DIGITS_PATTERN =
+        java.util.regex.Pattern.compile("^\\d+$");
 
     // Thread-safe maps for concurrent access
-    private final Map<String, ZipCode> zipCodesByCode = new ConcurrentHashMap<>();
+    private final NavigableMap<String, ZipCode> zipCodesByCode = new ConcurrentSkipListMap<>();
     // Inverted indices for fast searches by entity and municipality
     private final Map<String, Set<ZipCode>> zipCodesByNormalizedEntity = new ConcurrentHashMap<>();
     private final Map<String, Set<ZipCode>> zipCodesByNormalizedMunicipality = new ConcurrentHashMap<>();
@@ -408,7 +411,7 @@ public class ZipCodeService {
             String cleanCode = partialCode.trim();
 
             // Validar que solo contenga dígitos
-            if (!cleanCode.matches("\\d+")) {
+            if (!DIGITS_PATTERN.matcher(cleanCode).matches()) {
                 metricsConfiguration.recordSearchError("partial", "invalid_format");
                 throw new IllegalArgumentException("El código postal solo debe contener dígitos");
             }
@@ -416,10 +419,10 @@ public class ZipCodeService {
             // Limitar el tamaño del resultado
             int effectiveLimit = Math.min(Math.max(limit, 1), 50);
 
-            List<ZipCode> results = zipCodesByCode.entrySet().parallelStream()
-                    .filter(entry -> entry.getKey().startsWith(cleanCode))
-                    .map(Map.Entry::getValue)
-                    .sorted(Comparator.comparing(ZipCode::getZipCode))
+            String upperBound = cleanCode + Character.MAX_VALUE;
+            List<ZipCode> results = zipCodesByCode.subMap(cleanCode, true, upperBound, false)
+                    .values()
+                    .stream()
                     .limit(effectiveLimit)
                     .collect(Collectors.toList());
 

--- a/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
@@ -152,6 +152,26 @@ class ZipCodeServiceTest {
     }
 
     @Test
+    @DisplayName("Debe buscar códigos postales por prefijo respetando orden y límite")
+    void shouldSearchByPartialZipCodePrefixWithLimit() {
+        List<ZipCode> results = zipCodeService.searchByPartialCode("010", 3);
+
+        assertNotNull(results, "Los resultados no deben ser null");
+        assertFalse(results.isEmpty(), "Debe encontrar códigos postales con prefijo 010");
+        assertTrue(results.size() <= 3, "Debe respetar el límite solicitado");
+        assertTrue(results.stream().allMatch(zipCode -> zipCode.getZipCode().startsWith("010")),
+            "Todos los códigos postales deben iniciar con el prefijo buscado");
+
+        List<String> zipCodes = results.stream()
+                .map(ZipCode::getZipCode)
+                .toList();
+        List<String> sortedZipCodes = zipCodes.stream()
+                .sorted()
+                .toList();
+        assertEquals(sortedZipCodes, zipCodes, "Los códigos postales deben regresar ordenados");
+    }
+
+    @Test
     @DisplayName("Debe obtener estadísticas correctas")
     void shouldGetStatistics() {
         ZipCodeStats stats = zipCodeService.getStatistics();


### PR DESCRIPTION
### Motivation
- Mejorar el rendimiento de la búsqueda por prefijo en `searchByPartialCode` evitando escanear y ordenar todo el conjunto de códigos postales en cada llamada. 
- Reducir el coste de validación de formato al evitar recompilar patrones en cada petición. 
- Añadir cobertura de tests que verifique orden y límite en búsquedas por prefijo para prevenir regresiones.

### Description
- Reemplacé el mapa de lookup `Map<String, ZipCode> zipCodesByCode` por un `NavigableMap<String, ZipCode>` implementado con `ConcurrentSkipListMap` para permitir búsquedas por rango ordenadas sin ordenar manualmente los resultados. 
- Añadí un patrón precompilado `DIGITS_PATTERN` para validar el prefijo parcial y reemplacé `cleanCode.matches("\\d+")` por `DIGITS_PATTERN.matcher(cleanCode).matches()`. 
- Sustituí el filtrado por `startsWith` + stream por un `subMap(cleanCode, true, upperBound, false).values()` usando `upperBound = cleanCode + Character.MAX_VALUE` para limitar el rango de búsqueda por prefijo y respetar el orden natural de claves. 
- Agregué un test `shouldSearchByPartialZipCodePrefixWithLimit` en `ZipCodeServiceTest` que valida que la búsqueda por prefijo respeta el límite, que todos los resultados comparten el prefijo y que los resultados vienen ordenados.

### Testing
- Ejecuté `mvn test` y todos los tests unitarios pasaron con éxito. 
- Resultado de la suite: `BUILD SUCCESS` con `Tests run: 34, Failures: 0, Errors: 0, Skipped: 0`. 
- Archivos modificados principales: `src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java` y `src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe472848308321885d745a401d429e)