### PR TITLE
Optimize search cache key normalization

### DIFF
--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
@@ -349,7 +349,7 @@ public class ZipCodeService {
         return zipCode != null && ZIP_CODE_PATTERN.matcher(zipCode).matches();
     }
 
-    @Cacheable(value = "federalEntitySearch", key = "#searchTerm.toLowerCase()")
+    @Cacheable(value = "federalEntitySearch", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#searchTerm)")
     public List<ZipCode> searchByFederalEntity(String searchTerm) {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
@@ -360,7 +360,7 @@ public class ZipCodeService {
                 throw new IllegalArgumentException("El termino de busqueda no puede estar vacio");
             }
 
-            String normalizedSearchTerm = Util.normalizeString(searchTerm.trim());
+            String normalizedSearchTerm = Util.normalizeSearchTerm(searchTerm);
 
             // Sequential stream - only ~32 entries in the entity index, parallelStream overhead not worth it
             List<ZipCode> results = zipCodesByNormalizedEntity.entrySet().stream()
@@ -382,7 +382,7 @@ public class ZipCodeService {
         }
     }
 
-    @Cacheable(value = "municipalitySearch", key = "#searchTerm.toLowerCase()")
+    @Cacheable(value = "municipalitySearch", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#searchTerm)")
     public List<ZipCode> searchByMunicipality(String searchTerm) {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
@@ -393,7 +393,7 @@ public class ZipCodeService {
                 throw new IllegalArgumentException("El termino de busqueda no puede estar vacio");
             }
 
-            String normalizedSearchTerm = Util.normalizeString(searchTerm.trim());
+            String normalizedSearchTerm = Util.normalizeSearchTerm(searchTerm);
 
             // Sequential stream - municipality index has ~2500 entries, still fast enough sequentially
             List<ZipCode> results = zipCodesByNormalizedMunicipality.entrySet().stream()
@@ -430,7 +430,7 @@ public class ZipCodeService {
      * The upper bound is computed by incrementing the last character: "019" -> "020",
      * then using subMap("019", "020") which gives us all codes starting with "019".
      */
-    @Cacheable(value = "partialSearch", key = "#partialCode + '_' + #limit")
+    @Cacheable(value = "partialSearch", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#partialCode) + '_' + #limit")
     public List<ZipCode> searchByPartialCode(String partialCode, int limit) {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
@@ -501,7 +501,7 @@ public class ZipCodeService {
         }
     }
 
-    @Cacheable(value = "municipalitiesByEntity", key = "#federalEntity.toLowerCase()")
+    @Cacheable(value = "municipalitiesByEntity", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#federalEntity)")
     public List<String> getMunicipalitiesByFederalEntity(String federalEntity) {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
@@ -509,7 +509,7 @@ public class ZipCodeService {
                 throw new IllegalArgumentException("La entidad federativa no puede estar vacia");
             }
 
-            String normalizedSearchTerm = Util.normalizeString(federalEntity.trim());
+            String normalizedSearchTerm = Util.normalizeSearchTerm(federalEntity);
 
             // Sequential stream - only ~32 entity keys to filter
             List<String> municipalities = zipCodesByNormalizedEntity.entrySet().stream()
@@ -555,15 +555,15 @@ public class ZipCodeService {
             }
 
             String normalizedEntity = request.getFederalEntity() != null ?
-                    Util.normalizeString(request.getFederalEntity().trim()) : null;
+                    Util.normalizeSearchTerm(request.getFederalEntity()) : null;
             String normalizedMunicipality = request.getMunicipality() != null ?
-                    Util.normalizeString(request.getMunicipality().trim()) : null;
+                    Util.normalizeSearchTerm(request.getMunicipality()) : null;
             String normalizedSettlement = request.getSettlement() != null ?
-                    Util.normalizeString(request.getSettlement().trim()) : null;
+                    Util.normalizeSearchTerm(request.getSettlement()) : null;
             String normalizedSettlementType = request.getSettlementType() != null ?
-                    Util.normalizeString(request.getSettlementType().trim()) : null;
+                    Util.normalizeSearchTerm(request.getSettlementType()) : null;
             String normalizedZoneType = request.getZoneType() != null ?
-                    Util.normalizeString(request.getZoneType().trim()) : null;
+                    Util.normalizeSearchTerm(request.getZoneType()) : null;
 
             // Use inverted indices as starting point to reduce scan scope
             Collection<ZipCode> candidates = resolveSearchCandidates(normalizedEntity, normalizedMunicipality);

--- a/src/main/java/com/coderalexis/CodigoPostalApi/util/Util.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/util/Util.java
@@ -22,4 +22,25 @@ public class Util {
         // Remove diacritics, keep only base characters
         return DIACRITICS_PATTERN.matcher(normalized).replaceAll("").toLowerCase();
     }
+
+    /**
+     * Normalizes user-entered search text by trimming whitespace before removing
+     * accents and lowercasing, so semantically equivalent searches share the same value.
+     */
+    public static String normalizeSearchTerm(String input) {
+        if (input == null) {
+            return null;
+        }
+
+        return normalizeString(input.trim());
+    }
+
+    /**
+     * Builds a null-safe cache key for search terms. Invalid null/blank values still
+     * reach method validation instead of failing during Spring cache key evaluation.
+     */
+    public static String normalizeCacheKey(String input) {
+        String normalized = normalizeSearchTerm(input);
+        return normalized == null ? "" : normalized;
+    }
 }

--- a/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
@@ -93,6 +93,15 @@ class ZipCodeServiceTest {
         }, "Debe lanzar ZipCodeNotFoundException para entidad inexistente");
     }
 
+
+    @Test
+    @DisplayName("Debe validar nulos antes de generar la llave de cache en entidad")
+    void shouldValidateNullFederalEntityBeforeCacheKey() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            zipCodeService.searchByFederalEntity(null);
+        }, "Debe lanzar IllegalArgumentException para término null");
+    }
+
     @Test
     @DisplayName("Debe lanzar excepción para término de búsqueda vacío en entidad")
     void shouldThrowExceptionForEmptyFederalEntitySearch() {


### PR DESCRIPTION
### Motivation

- Evitar entradas duplicadas en caché provocadas por variaciones de mayúsculas, acentos o espacios en términos de búsqueda.
- Garantizar que valores nulos o en blanco lleguen a la validación del método en vez de romper la evaluación SpEL de la llave de caché.
- Centralizar la normalización para reducir duplicación y asegurar coherencia entre los endpoints de búsqueda.

### Description

- Añadida la utilidad `normalizeSearchTerm(String)` que recorta, elimina acentos y lowercases, y `normalizeCacheKey(String)` que genera una llave de caché nula-segura en `Util.java`.
- Actualizados los `@Cacheable` keys para usar `T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(...)` en búsquedas por entidad, municipio, búsqueda parcial y municipios por entidad en `ZipCodeService.java`.
- Reemplazada la normalización inline por `Util.normalizeSearchTerm(...)` en los métodos de búsqueda y en la búsqueda avanzada para reutilizar la lógica centralizada.
- Añadida prueba de regresión que valida que `searchByFederalEntity(null)` lanza `IllegalArgumentException` y por tanto no falla durante la evaluación de la llave de caché en `ZipCodeServiceTest.java`.

### Testing

- Ejecutado `./mvnw test` que falló por ausencia del wrapper (`.mvn/wrapper/maven-wrapper.properties`) en el repositorio, por lo que se usó Maven directamente.
- Ejecutado `mvn test` y todos los tests unitarios pasaron (`Tests run: 36, Failures: 0, Errors: 0, BUILD SUCCESS`), incluyendo la prueba agregada de null.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a014e73d3a883219a2eb84d88472093)