### PR TITLE
Optimize advanced search caching and candidate selection

### DIFF
--- a/src/main/java/com/coderalexis/CodigoPostalApi/model/AdvancedSearchRequest.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/model/AdvancedSearchRequest.java
@@ -1,5 +1,6 @@
 package com.coderalexis.CodigoPostalApi.model;
 
+import com.coderalexis.CodigoPostalApi.util.Util;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
@@ -51,4 +52,18 @@ public class AdvancedSearchRequest {
     @Schema(description = "Si es true, devuelve formato simplificado sin lista de asentamientos", example = "false")
     @Builder.Default
     private boolean simplified = false;
+
+    /**
+     * Stable cache key for the expensive, unpaged advanced-search result set.
+     * Page, size, and simplified are intentionally excluded because pagination
+     * and presentation mapping are applied after retrieving the full result list.
+     */
+    public String normalizedFilterCacheKey() {
+        return String.join("|",
+                Util.normalizeCacheKey(federalEntity),
+                Util.normalizeCacheKey(municipality),
+                Util.normalizeCacheKey(settlement),
+                Util.normalizeCacheKey(settlementType),
+                Util.normalizeCacheKey(zoneType));
+    }
 }

--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
@@ -542,7 +542,7 @@ public class ZipCodeService {
      * Advanced search using inverted indices as starting point when possible.
      * Uses pre-computed normalized fields to avoid runtime normalization.
      */
-    @Cacheable(value = "advancedSearch", key = "#request.toString()")
+    @Cacheable(value = "advancedSearch", key = "#request.normalizedFilterCacheKey()")
     public List<ZipCode> advancedSearch(AdvancedSearchRequest request) {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
@@ -674,32 +674,55 @@ public class ZipCodeService {
 
     /**
      * Resolves the smallest candidate set using available inverted indices.
-     * Prefers entity index (fewer entries) over municipality, falls back to full scan only when needed.
+     *
+     * If an indexed filter is present but has no matches, it returns an empty
+     * candidate set immediately because advanced-search filters are combined with
+     * AND semantics. This avoids a full catalog scan for impossible entity or
+     * municipality criteria.
      */
     private Collection<ZipCode> resolveSearchCandidates(String normalizedEntity, String normalizedMunicipality) {
-        // If entity filter is present, use entity index (narrows to ~2K from ~32K)
-        if (normalizedEntity != null && !normalizedEntity.isEmpty()) {
-            Set<ZipCode> candidates = new HashSet<>();
-            zipCodesByNormalizedEntity.entrySet().stream()
-                    .filter(entry -> entry.getKey().contains(normalizedEntity))
-                    .forEach(entry -> candidates.addAll(entry.getValue()));
-            if (!candidates.isEmpty()) {
-                return candidates;
-            }
+        Set<ZipCode> entityCandidates = findCandidatesInIndex(zipCodesByNormalizedEntity, normalizedEntity);
+        if (isFilterPresent(normalizedEntity) && entityCandidates.isEmpty()) {
+            return List.of();
         }
 
-        // If municipality filter is present, use municipality index
-        if (normalizedMunicipality != null && !normalizedMunicipality.isEmpty()) {
-            Set<ZipCode> candidates = new HashSet<>();
-            zipCodesByNormalizedMunicipality.entrySet().stream()
-                    .filter(entry -> entry.getKey().contains(normalizedMunicipality))
-                    .forEach(entry -> candidates.addAll(entry.getValue()));
-            if (!candidates.isEmpty()) {
-                return candidates;
-            }
+        Set<ZipCode> municipalityCandidates = findCandidatesInIndex(
+                zipCodesByNormalizedMunicipality, normalizedMunicipality);
+        if (isFilterPresent(normalizedMunicipality) && municipalityCandidates.isEmpty()) {
+            return List.of();
         }
 
-        // Fallback: full scan (only when filtering by settlement/type/zone only)
+        if (!entityCandidates.isEmpty() && !municipalityCandidates.isEmpty()) {
+            return entityCandidates.size() <= municipalityCandidates.size()
+                    ? entityCandidates
+                    : municipalityCandidates;
+        }
+
+        if (!entityCandidates.isEmpty()) {
+            return entityCandidates;
+        }
+
+        if (!municipalityCandidates.isEmpty()) {
+            return municipalityCandidates;
+        }
+
+        // Fallback: full scan only when filtering by settlement/type/zone.
         return zipCodesByCode.values();
+    }
+
+    private Set<ZipCode> findCandidatesInIndex(Map<String, Set<ZipCode>> index, String normalizedSearchTerm) {
+        if (!isFilterPresent(normalizedSearchTerm)) {
+            return Set.of();
+        }
+
+        Set<ZipCode> candidates = new HashSet<>();
+        index.entrySet().stream()
+                .filter(entry -> entry.getKey().contains(normalizedSearchTerm))
+                .forEach(entry -> candidates.addAll(entry.getValue()));
+        return candidates;
+    }
+
+    private boolean isFilterPresent(String normalizedSearchTerm) {
+        return normalizedSearchTerm != null && !normalizedSearchTerm.isEmpty();
     }
 }

--- a/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
@@ -1,6 +1,7 @@
 package com.coderalexis.CodigoPostalApi.service;
 
 import com.coderalexis.CodigoPostalApi.exceptions.ZipCodeNotFoundException;
+import com.coderalexis.CodigoPostalApi.model.AdvancedSearchRequest;
 import com.coderalexis.CodigoPostalApi.model.ZipCode;
 import com.coderalexis.CodigoPostalApi.model.ZipCodeStats;
 import org.junit.jupiter.api.Test;
@@ -213,5 +214,30 @@ class ZipCodeServiceTest {
         assertNotNull(results);
         // Este test puede pasar o fallar dependiendo del contenido del archivo
         // Si no hay municipios con "gua", ajusta el término de búsqueda
+    }
+
+    @Test
+    @DisplayName("Debe usar la misma llave de cache avanzada para distintas paginas y formatos")
+    void shouldUseSameAdvancedSearchCacheKeyForPaginationAndFormatOptions() {
+        AdvancedSearchRequest firstPage = AdvancedSearchRequest.builder()
+                .federalEntity(" Jalisco ")
+                .municipality("Guadalajara")
+                .zoneType("Urbano")
+                .page(0)
+                .size(20)
+                .simplified(false)
+                .build();
+
+        AdvancedSearchRequest secondPageSimplified = AdvancedSearchRequest.builder()
+                .federalEntity("jalisco")
+                .municipality("guadalajara")
+                .zoneType("urbano")
+                .page(3)
+                .size(5)
+                .simplified(true)
+                .build();
+
+        assertEquals(firstPage.normalizedFilterCacheKey(), secondPageSimplified.normalizedFilterCacheKey(),
+            "La cache de busqueda avanzada debe depender solo de los filtros normalizados");
     }
 }


### PR DESCRIPTION
### Motivation

- Reduce unnecessary cache fragmentation caused by including pagination and presentation options in the advanced-search cache key.
- Avoid expensive full-catalog scans when indexed filters (federal entity / municipality) make the query impossible or when a smaller indexed candidate set can be used.

### Description

- Add `normalizedFilterCacheKey()` to `AdvancedSearchRequest` that returns a stable cache key built only from normalized filter fields and excludes `page`, `size` and `simplified`.
- Change the `@Cacheable` key for `advancedSearch` in `ZipCodeService` to use `#request.normalizedFilterCacheKey()` instead of `#request.toString()` so different pagination/format options reuse the same cached result.
- Replace the previous candidate-resolution logic with `findCandidatesInIndex(...)` and `isFilterPresent(...)` so that (a) an indexed filter with no matches returns an empty candidate set early, and (b) when both entity and municipality indexes match, the smaller candidate set is chosen to minimize subsequent filtering work.
- Add a unit test `shouldUseSameAdvancedSearchCacheKeyForPaginationAndFormatOptions` in `ZipCodeServiceTest` that verifies the normalized cache key is the same for semantically equivalent filters with different page/size/simplified values.

### Testing

- `./mvnw test -q` failed due to a missing Maven wrapper file (`.mvn/wrapper/maven-wrapper.properties`).
- `mvn -q -Dtest=ZipCodeServiceTest test` was executed and the focused test class passed successfully.
- `mvn test -q` (full test suite) was executed and completed without failures in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0158decf888321aae4ab3f1ac07c60)