### PR TITLE
Corregir agrupación de configuración en application-prod.yml

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,6 +8,11 @@ spring:
   config:
     activate:
       on-profile: prod
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+  cache:
+    caffeine:
+      spec: maximumSize=10000,expireAfterAccess=1h,recordStats
 
 # Rate limiting estricto en producción
 ratelimit:
@@ -44,8 +49,8 @@ logging:
     max-size: 10MB
     max-history: 30
 
-# Servidor con errores ocultos
 server:
+  # Servidor con errores ocultos
   error:
     include-message: never  # NUNCA incluir mensajes de error internos
     include-stacktrace: never
@@ -53,23 +58,10 @@ server:
     include-binding-errors: never
     whitelabel:
       enabled: false  # Deshabilitar página de error por defecto
-
-# Compresión optimizada
-server:
+  # Compresión optimizada
   compression:
     enabled: true
     mime-types: application/json,application/xml,text/html,text/xml,text/plain
     min-response-size: 512  # Comprimir respuestas > 512 bytes
-
-# Seguridad adicional
-server:
+  # Seguridad adicional
   shutdown: graceful  # Apagado graceful
-spring:
-  lifecycle:
-    timeout-per-shutdown-phase: 30s
-
-# Caché optimizado para producción
-spring:
-  cache:
-    caffeine:
-      spec: maximumSize=10000,expireAfterAccess=1h,recordStats


### PR DESCRIPTION
### Motivation
- El archivo de producción `application-prod.yml` contenía secciones raíz duplicadas (`spring` y `server`) que podían provocar que ciertas configuraciones de producción (timeout de apagado, spec de cache, compresión, ocultamiento de errores, shutdown) quedaran fragmentadas o sobrescritas, por lo que se unifican para garantizar que las propiedades se apliquen correctamente.

### Description
- Se consolidaron las entradas `spring` en `src/main/resources/application-prod.yml` moviendo `lifecycle.timeout-per-shutdown-phase` y la especificación de `spring.cache.caffeine.spec` bajo el mismo bloque `spring` para evitar duplicidad de claves.
- Se unificaron las entradas `server` en el mismo fichero para agrupar `error`, `compression` y `shutdown` en un solo bloque `server`, preservando la semántica de ocultamiento de errores, compresión optimizada y apagado graceful.

### Testing
- Ejecuté `mvn test` y la suite completa terminó con éxito (todas las pruebas pasan).
- Ejecuté `mvn -Dspring.profiles.active=prod -Dtest=CodigoPostalApiApplicationTests test` para validar arranque con perfil `prod` y la prueba específica pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02c438e788832192e2e5c495647420)