### PR TITLE
Aplicar 25 mejoras: bugs, performance, seguridad y refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,13 @@
 		<tag/>
 		<url/>
 	</scm>
+	<!--
+		Fix #21: removida la propiedad <lombok.version>. Spring Boot 4.0.6 ya
+		gestiona la versión de Lombok desde su BOM y sobrescribirla podía
+		causar incompatibilidades sutiles con el annotation processor.
+	-->
 	<properties>
 		<java.version>25</java.version>
-		<lombok.version>1.18.40</lombok.version>
 		<springdoc.version>3.0.1</springdoc.version>
 		<bucket4j.version>8.10.1</bucket4j.version>
 	</properties>
@@ -70,11 +74,10 @@
 			<version>${bucket4j.version}</version>
 		</dependency>
 
-		<!-- Lombok -->
+		<!-- Lombok (versión gestionada por el BOM de Spring Boot) -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>${lombok.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -121,7 +124,6 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
-							<version>${lombok.version}</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/src/main/java/com/coderalexis/CodigoPostalApi/config/CacheConfiguration.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/config/CacheConfiguration.java
@@ -1,6 +1,8 @@
 package com.coderalexis.CodigoPostalApi.config;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
@@ -13,6 +15,12 @@ import java.util.concurrent.TimeUnit;
 @EnableCaching
 public class CacheConfiguration {
 
+    private final MeterRegistry meterRegistry;
+
+    public CacheConfiguration(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
     @Bean
     public CacheManager cacheManager() {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager(
@@ -21,7 +29,6 @@ public class CacheConfiguration {
                 "federalEntitySearchPaged",
                 "municipalitySearch",
                 "municipalitySearchPaged",
-                "partialSearch",
                 "federalEntities",
                 "municipalitiesByEntity",
                 "advancedSearch",
@@ -30,7 +37,7 @@ public class CacheConfiguration {
 
         // Direct zip code lookup: O(1) in-memory Map access, no cache benefit.
         // Kept for backward compatibility with @Cacheable annotations.
-        cacheManager.registerCustomCache("zipcodes",
+        registerCache(cacheManager, "zipcodes",
                 Caffeine.newBuilder()
                         .maximumSize(10_000)
                         .expireAfterAccess(1, TimeUnit.HOURS)
@@ -38,8 +45,7 @@ public class CacheConfiguration {
                         .build());
 
         // Federal entity search: results can be large (full ZipCode objects with settlements).
-        // Reduced size and TTL to avoid memory pressure. Consider caching only zip IDs if needed.
-        cacheManager.registerCustomCache("federalEntitySearch",
+        registerCache(cacheManager, "federalEntitySearch",
                 Caffeine.newBuilder()
                         .maximumSize(50)
                         .expireAfterWrite(5, TimeUnit.MINUTES)
@@ -47,66 +53,53 @@ public class CacheConfiguration {
                         .build());
 
         // Paginated variant: more specific keys, separate cache entry.
-        cacheManager.registerCustomCache("federalEntitySearchPaged",
+        registerCache(cacheManager, "federalEntitySearchPaged",
                 Caffeine.newBuilder()
                         .maximumSize(100)
                         .expireAfterWrite(5, TimeUnit.MINUTES)
                         .recordStats()
                         .build());
 
-        // Municipality search: results can be very large. Conservative cache settings.
-        cacheManager.registerCustomCache("municipalitySearch",
+        registerCache(cacheManager, "municipalitySearch",
                 Caffeine.newBuilder()
                         .maximumSize(100)
                         .expireAfterWrite(5, TimeUnit.MINUTES)
                         .recordStats()
                         .build());
 
-        // Paginated municipality variant.
-        cacheManager.registerCustomCache("municipalitySearchPaged",
+        registerCache(cacheManager, "municipalitySearchPaged",
                 Caffeine.newBuilder()
                         .maximumSize(100)
                         .expireAfterWrite(5, TimeUnit.MINUTES)
                         .recordStats()
                         .build());
 
-        // Partial search (autocomplete): frequent reads, moderate cache.
-        cacheManager.registerCustomCache("partialSearch",
-                Caffeine.newBuilder()
-                        .maximumSize(500)
-                        .expireAfterWrite(10, TimeUnit.MINUTES)
-                        .recordStats()
-                        .build());
+        // NOTA: la cache de búsqueda parcial (autocompletado) se gestiona directamente
+        // con Caffeine en ZipCodeService para evitar la trampa de self-invocation de
+        // Spring Cache.
 
-        // Federal entities list: rarely changes, small result set.
-        cacheManager.registerCustomCache("federalEntities",
+        registerCache(cacheManager, "federalEntities",
                 Caffeine.newBuilder()
                         .maximumSize(1)
                         .expireAfterWrite(1, TimeUnit.HOURS)
                         .recordStats()
                         .build());
 
-        // Municipalities by entity: small result sets, moderate TTL.
-        cacheManager.registerCustomCache("municipalitiesByEntity",
+        registerCache(cacheManager, "municipalitiesByEntity",
                 Caffeine.newBuilder()
                         .maximumSize(50)
                         .expireAfterWrite(30, TimeUnit.MINUTES)
                         .recordStats()
                         .build());
 
-        // Advanced search: can return large result sets. Conservative settings.
-        // If memory usage is high, consider caching only zip code IDs instead of
-        // full ZipCode objects (which include nested settlement lists).
-        cacheManager.registerCustomCache("advancedSearch",
+        registerCache(cacheManager, "advancedSearch",
                 Caffeine.newBuilder()
                         .maximumSize(25)
                         .expireAfterWrite(5, TimeUnit.MINUTES)
                         .recordStats()
                         .build());
 
-        // Paginated advanced search: smaller values than unpaged results, with
-        // page-aware keys to reduce repeated filtering for common queries.
-        cacheManager.registerCustomCache("advancedSearchPaged",
+        registerCache(cacheManager, "advancedSearchPaged",
                 Caffeine.newBuilder()
                         .maximumSize(100)
                         .expireAfterWrite(5, TimeUnit.MINUTES)
@@ -114,5 +107,19 @@ public class CacheConfiguration {
                         .build());
 
         return cacheManager;
+    }
+
+    /**
+     * Registra una caché y la enlaza al MeterRegistry para que las estadísticas
+     * generadas por {@code recordStats()} (hit ratio, evictions, load duration,
+     * etc.) queden expuestas vía Prometheus/Micrometer. Antes se activaba
+     * {@code recordStats()} pero nadie las cosechaba, lo cual sólo añadía
+     * overhead sin beneficio. Fix #13.
+     */
+    private void registerCache(CaffeineCacheManager cacheManager,
+                               String name,
+                               com.github.benmanes.caffeine.cache.Cache<Object, Object> cache) {
+        cacheManager.registerCustomCache(name, cache);
+        CaffeineCacheMetrics.monitor(meterRegistry, cache, name);
     }
 }

--- a/src/main/java/com/coderalexis/CodigoPostalApi/config/CacheControlInterceptor.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/config/CacheControlInterceptor.java
@@ -1,0 +1,77 @@
+package com.coderalexis.CodigoPostalApi.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.CacheControl;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+/**
+ * Añade {@code Cache-Control} a las respuestas REST exitosas según el patrón
+ * de la URI. Fix #23: antes sólo los recursos estáticos llevaban Cache-Control,
+ * con lo cual CDNs y clientes no podían cachear nada del API. Los TTL son
+ * conservadores y reflejan la estabilidad real del catálogo SEPOMEX (los
+ * códigos postales cambian con muy baja frecuencia).
+ *
+ * <p>No se aplica a respuestas de error (4xx/5xx) para evitar que un fallo
+ * transitorio quede cacheado en intermediarios.</p>
+ */
+@Component
+public class CacheControlInterceptor implements HandlerInterceptor {
+
+    private static final String CACHE_CONTROL_HEADER = "Cache-Control";
+
+    // LinkedHashMap preserva el orden de declaración; las reglas más específicas van primero.
+    private static final Map<Pattern, String> RULES = new LinkedHashMap<>();
+
+    static {
+        // Datos muy estables: catálogo completo de estados.
+        RULES.put(Pattern.compile("^/zip-codes/federal-entities/?$"),
+                CacheControl.maxAge(6, TimeUnit.HOURS).cachePublic().getHeaderValue());
+
+        // Datos estables a la escala de horas: lookup directo, asentamientos, stats, municipios.
+        String oneHour = CacheControl.maxAge(1, TimeUnit.HOURS).cachePublic().getHeaderValue();
+        RULES.put(Pattern.compile("^/zip-codes/\\d{5}$"), oneHour);
+        RULES.put(Pattern.compile("^/zip-codes/\\d{5}/settlements$"), oneHour);
+        RULES.put(Pattern.compile("^/zip-codes/stats$"), oneHour);
+        RULES.put(Pattern.compile("^/zip-codes/federal-entities/[^/]+/municipalities$"), oneHour);
+
+        // Búsquedas: respuesta más volátil por términos arbitrarios; TTL más corto.
+        String halfHour = CacheControl.maxAge(30, TimeUnit.MINUTES).cachePublic().getHeaderValue();
+        RULES.put(Pattern.compile("^/zip-codes/search$"), halfHour);
+        RULES.put(Pattern.compile("^/zip-codes/by-municipality$"), halfHour);
+        RULES.put(Pattern.compile("^/zip-codes/advanced$"), halfHour);
+        // Listado por entidad federativa (raíz del recurso): /zip-codes?federal_entity=...
+        RULES.put(Pattern.compile("^/zip-codes/?$"), halfHour);
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request,
+                                HttpServletResponse response,
+                                Object handler,
+                                Exception ex) {
+        if (ex != null || response.getStatus() >= 400) {
+            // No cacheamos errores: un 404 transitorio no debería quedarse pegado en
+            // un CDN.
+            return;
+        }
+
+        if (response.containsHeader(CACHE_CONTROL_HEADER)) {
+            // Ya configurado por el controlador, no sobreescribir.
+            return;
+        }
+
+        String uri = request.getRequestURI();
+        for (Map.Entry<Pattern, String> rule : RULES.entrySet()) {
+            if (rule.getKey().matcher(uri).matches()) {
+                response.setHeader(CACHE_CONTROL_HEADER, rule.getValue());
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/com/coderalexis/CodigoPostalApi/config/RateLimitInterceptor.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/config/RateLimitInterceptor.java
@@ -1,5 +1,10 @@
 package com.coderalexis.CodigoPostalApi.config;
 
+import com.coderalexis.CodigoPostalApi.exceptions.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.Bandwidth;
@@ -8,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -15,17 +21,34 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Rate limiting interceptor using Token Bucket algorithm (Bucket4j).
  * Uses Caffeine cache for automatic bucket eviction to prevent memory leaks.
+ *
+ * <p>Fix #3: la IP del cliente se obtiene exclusivamente via
+ * {@code request.getRemoteAddr()}. En entornos detrás de proxy/CDN se debe
+ * habilitar {@code server.forward-headers-strategy=framework} (configurado en
+ * los perfiles prod/railway) para que Spring Boot resuelva la cadena de
+ * X-Forwarded-* a través de su filtro ya validado, en vez de confiar a ciegas
+ * en el header (que es spoofable trivialmente).</p>
  */
 @Slf4j
 @Component
 public class RateLimitInterceptor implements HandlerInterceptor {
 
     private final RateLimitProperties rateLimitProperties;
+    // ObjectMapper privado con JSR310 registrado. Antes lo inyectábamos por
+    // constructor pero el orden de inicialización (WebMvc → Interceptors →
+    // JacksonAutoConfiguration) provocaba que la dependencia no estuviera
+    // disponible en algunos contextos de test. Como sólo serializamos un
+    // ErrorResponse, una instancia local autosuficiente es más robusta.
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
+            .addModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
     // Caffeine cache with TTL-based eviction (buckets expire after 5 minutes of inactivity)
     private final Cache<String, Bucket> bucketCache;
 
@@ -61,18 +84,33 @@ public class RateLimitInterceptor implements HandlerInterceptor {
         }
 
         log.warn("Rate limit excedido para IP: {}", clientIp);
+        writeRateLimitExceededResponse(request, response);
+        return false;
+    }
+
+    /**
+     * Fix #7: serializa la respuesta 429 reusando {@link ErrorResponse} y
+     * {@link ObjectMapper} para mantener el mismo formato que el resto de
+     * errores (timestamp formateado, status, message, path) en vez de
+     * construir el JSON con {@code String.format}.
+     */
+    private void writeRateLimitExceededResponse(HttpServletRequest request, HttpServletResponse response)
+            throws java.io.IOException {
         response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
         response.setHeader("X-RateLimit-Limit", String.valueOf(rateLimitProperties.getRequestsPerMinute()));
         response.setHeader("X-RateLimit-Remaining", "0");
         response.setHeader("X-RateLimit-Retry-After-Seconds", "60");
-        response.setContentType("application/json");
-        response.getWriter().write(String.format(
-            "{\"status\":429,\"message\":\"Limite de peticiones excedido. Maximo %d peticiones por minuto.\",\"timestamp\":\"%s\"}",
-            rateLimitProperties.getRequestsPerMinute(),
-            java.time.LocalDateTime.now()
-        ));
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-        return false;
+        ErrorResponse body = new ErrorResponse(
+                HttpStatus.TOO_MANY_REQUESTS.value(),
+                String.format("Limite de peticiones excedido. Maximo %d peticiones por minuto.",
+                        rateLimitProperties.getRequestsPerMinute()),
+                request.getRequestURI(),
+                LocalDateTime.now()
+        );
+
+        OBJECT_MAPPER.writeValue(response.getWriter(), body);
     }
 
     private Bucket createNewBucket() {
@@ -86,12 +124,15 @@ public class RateLimitInterceptor implements HandlerInterceptor {
                 .build();
     }
 
+    /**
+     * Devuelve la IP real del cliente. Spring Boot, cuando
+     * {@code server.forward-headers-strategy} está en {@code framework} o
+     * {@code native}, ya resuelve {@code request.getRemoteAddr()} a la IP
+     * propagada por el proxy de confianza. Si no hay proxy configurado, este
+     * método cae a la IP TCP directa, que tampoco es spoofable.
+     */
     private String getClientIP(HttpServletRequest request) {
-        String xfHeader = request.getHeader("X-Forwarded-For");
-        if (xfHeader == null || xfHeader.isEmpty() || "unknown".equalsIgnoreCase(xfHeader)) {
-            return request.getRemoteAddr();
-        }
-        return xfHeader.split(",")[0].trim();
+        return request.getRemoteAddr();
     }
 
     private boolean isWhitelisted(String ip) {

--- a/src/main/java/com/coderalexis/CodigoPostalApi/config/WebMvcConfiguration.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/config/WebMvcConfiguration.java
@@ -18,22 +18,31 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
 
     private final RateLimitInterceptor rateLimitInterceptor;
     private final RateLimitProperties rateLimitProperties;
+    private final CacheControlInterceptor cacheControlInterceptor;
 
     public WebMvcConfiguration(RateLimitInterceptor rateLimitInterceptor,
-                              RateLimitProperties rateLimitProperties) {
+                              RateLimitProperties rateLimitProperties,
+                              CacheControlInterceptor cacheControlInterceptor) {
         this.rateLimitInterceptor = rateLimitInterceptor;
         this.rateLimitProperties = rateLimitProperties;
+        this.cacheControlInterceptor = cacheControlInterceptor;
     }
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        // Cache-Control headers for API responses
+        // Cache-Control para recursos estáticos (favicon, etc.). Las respuestas REST
+        // usan CacheControlInterceptor (#23) que aplica TTLs específicos por endpoint.
         registry.addResourceHandler("/**")
                 .setCacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES).cachePrivate());
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
+        // Cache-Control para endpoints REST: se registra primero para que las
+        // respuestas exitosas siempre lleven el header adecuado.
+        registry.addInterceptor(cacheControlInterceptor)
+                .addPathPatterns("/zip-codes/**", "/zip-codes");
+
         if (rateLimitProperties.isEnabled()) {
             log.info("✓ Rate Limiting HABILITADO: {} req/min, Burst: {}",
                 rateLimitProperties.getRequestsPerMinute(),

--- a/src/main/java/com/coderalexis/CodigoPostalApi/controller/Controller.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/controller/Controller.java
@@ -1,6 +1,5 @@
 package com.coderalexis.CodigoPostalApi.controller;
 
-import com.coderalexis.CodigoPostalApi.exceptions.ErrorResponse;
 import com.coderalexis.CodigoPostalApi.model.AdvancedSearchRequest;
 import com.coderalexis.CodigoPostalApi.model.FederalEntity;
 import com.coderalexis.CodigoPostalApi.model.PagedResponse;
@@ -9,30 +8,22 @@ import com.coderalexis.CodigoPostalApi.model.ZipCode;
 import com.coderalexis.CodigoPostalApi.model.ZipCodeSimplified;
 import com.coderalexis.CodigoPostalApi.model.ZipCodeStats;
 import com.coderalexis.CodigoPostalApi.service.ZipCodeService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+/**
+ * Implementación de {@link ZipCodeApi}. Tras el refactor #16 esta clase
+ * contiene exclusivamente la lógica de orquestación: la documentación OpenAPI,
+ * las anotaciones de validación y los mapeos REST viven en la interfaz.
+ */
 @RestController
 @Slf4j
-@RequestMapping("/zip-codes")
 @Validated
-public class Controller {
+public class Controller implements ZipCodeApi {
 
     private final ZipCodeService zipCodeService;
 
@@ -40,525 +31,69 @@ public class Controller {
         this.zipCodeService = zipCodeService;
     }
 
-    @Operation(
-            summary = "🔍 Buscar código postal específico",
-            description = """
-                    Obtiene información completa de un código postal específico incluyendo:
-                    - Entidad federativa
-                    - Municipio
-                    - Localidad
-                    - Lista de asentamientos (colonias, fraccionamientos, etc.)
-
-                    ### Ejemplos de uso:
-                    - `01000` - San Ángel, Ciudad de México
-                    - `44100` - Guadalajara Centro, Jalisco
-                    - `64000` - Monterrey Centro, Nuevo León
-
-                    ### Rendimiento:
-                    Este endpoint está optimizado con caché, tiempo de respuesta típico: **~50ms**
-                    """,
-            tags = {"Búsqueda Directa"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "Código postal encontrado",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ZipCode.class))
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "Formato de código postal inválido",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "Código postal no encontrado",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            )
-    })
-    @GetMapping("/{zipcode}")
-    public ResponseEntity<ZipCode> getZipCode(
-            @Parameter(
-                    description = "El código postal a buscar",
-                    required = true,
-                    example = "01000"
-            )
-            @PathVariable("zipcode")
-            @Pattern(regexp = "\\d{5}", message = "El código postal debe tener exactamente 5 dígitos")
-            String zipcode
-    ) {
-        ZipCode response = zipCodeService.getZipCode(zipcode);
-        return ResponseEntity.ok(response);
+    @Override
+    public ResponseEntity<ZipCode> getZipCode(String zipcode) {
+        return ResponseEntity.ok(zipCodeService.getZipCode(zipcode));
     }
 
-    @Operation(
-            summary = "🗺️ Buscar por entidad federativa (estado)",
-            description = """
-                    Busca códigos postales por entidad federativa con paginación automática.
-
-                    ### Características:
-                    - ✅ Búsqueda parcial (ej: "mex" encuentra "México", "Nuevo México")
-                    - ✅ Insensible a acentos ("Mexico" = "México")
-                    - ✅ Insensible a mayúsculas
-                    - ✅ Resultados paginados
-
-                    ### Ejemplos:
-                    - `federal_entity=Ciudad de México&page=0&size=20`
-                    - `federal_entity=jalisco&page=0&size=10`
-                    - `federal_entity=nuevo leon` (sin acentos)
-
-                    ### Parámetros de paginación:
-                    - `page`: Número de página (inicia en 0)
-                    - `size`: Elementos por página (1-100, default: 20)
-                    """,
-            tags = {"Búsqueda por Ubicación"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "Lista de códigos postales que coinciden con la entidad federativa",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = PagedResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "Parámetros de búsqueda inválidos",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "No se encontraron códigos postales para la entidad federativa proporcionada",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            )
-    })
-    @GetMapping
-    public ResponseEntity<PagedResponse<ZipCode>> searchByFederalEntity(
-            @Parameter(
-                    description = "Término de búsqueda para la entidad federativa (puede ser parcial)",
-                    required = true,
-                    example = "mexico"
-            )
-            @RequestParam("federal_entity")
-            @NotBlank(message = "El término de búsqueda no puede estar vacío")
-            String federalEntity,
-
-            @Parameter(description = "Número de página (comienza en 0)")
-            @RequestParam(value = "page", defaultValue = "0")
-            @Min(value = 0, message = "La página debe ser mayor o igual a 0")
-            @Max(value = 10_000, message = "El número de página es inválido")
-            int page,
-
-            @Parameter(description = "Tamaño de página")
-            @RequestParam(value = "size", defaultValue = "20")
-            @Min(value = 1, message = "El tamaño debe ser mayor a 0")
-            @Max(value = 100, message = "El tamaño máximo es 100")
-            int size
-    ) {
-        // Service handles pagination internally, avoiding full list materialization
-        PagedResponse<ZipCode> response = zipCodeService.searchByFederalEntity(federalEntity, page, size);
-        return ResponseEntity.ok(response);
+    @Override
+    public ResponseEntity<PagedResponse<ZipCode>> searchByFederalEntity(String federalEntity, int page, int size) {
+        return ResponseEntity.ok(zipCodeService.searchByFederalEntity(federalEntity, page, size));
     }
 
-
-    @Operation(
-            summary = "🏘️ Buscar por municipio",
-            description = """
-                    Busca códigos postales por municipio con paginación.
-
-                    ### Características:
-                    - ✅ Búsqueda parcial
-                    - ✅ Insensible a acentos y mayúsculas
-                    - ✅ Resultados paginados
-
-                    ### Ejemplos:
-                    - `municipality=Guadalajara&page=0&size=20`
-                    - `municipality=Alvaro Obregon` (sin acentos)
-                    - `municipality=monte&page=0` (búsqueda parcial)
-                    """,
-            tags = {"Búsqueda por Ubicación"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "Lista de códigos postales que coinciden con el municipio",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = PagedResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "Parámetros de búsqueda inválidos",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "No se encontraron códigos postales para el municipio proporcionado",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            )
-    })
-    @GetMapping("/by-municipality")
-    public ResponseEntity<PagedResponse<ZipCode>> searchByMunicipality(
-            @Parameter(
-                    description = "Término de búsqueda para el municipio (puede ser parcial)",
-                    required = true,
-                    example = "Guadalajara"
-            )
-            @RequestParam("municipality")
-            @NotBlank(message = "El municipio no puede estar vacío")
-            String municipality,
-
-            @Parameter(description = "Número de página (comienza en 0)")
-            @RequestParam(value = "page", defaultValue = "0")
-            @Min(value = 0, message = "La página debe ser mayor o igual a 0")
-            @Max(value = 10_000, message = "El número de página es inválido")
-            int page,
-
-            @Parameter(description = "Tamaño de página")
-            @RequestParam(value = "size", defaultValue = "20")
-            @Min(value = 1, message = "El tamaño debe ser mayor a 0")
-            @Max(value = 100, message = "El tamaño máximo es 100")
-            int size
-    ) {
-        // Service handles pagination internally, avoiding full list materialization
-        PagedResponse<ZipCode> response = zipCodeService.searchByMunicipality(municipality, page, size);
-        return ResponseEntity.ok(response);
+    @Override
+    public ResponseEntity<PagedResponse<ZipCode>> searchByMunicipality(String municipality, int page, int size) {
+        return ResponseEntity.ok(zipCodeService.searchByMunicipality(municipality, page, size));
     }
 
-    @Operation(
-            summary = "📊 Estadísticas generales",
-            description = """
-                    Obtiene estadísticas sobre el catálogo completo de códigos postales.
-
-                    ### Información incluida:
-                    - Total de códigos postales únicos
-                    - Total de entidades federativas
-                    - Total de municipios
-                    - Total de asentamientos (colonias, fraccionamientos, etc.)
-
-                    ### Ejemplo de respuesta:
-                    ```json
-                    {
-                      "totalZipCodes": 145000,
-                      "totalFederalEntities": 32,
-                      "totalMunicipalities": 2469,
-                      "totalSettlements": 285000
-                    }
-                    ```
-
-                    ### Uso:
-                    Útil para conocer la cobertura del catálogo y validar la integridad de los datos.
-                    """,
-            tags = {"Estadísticas"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "Estadísticas obtenidas exitosamente",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ZipCodeStats.class))
-            )
-    })
-    @GetMapping("/stats")
+    @Override
     public ResponseEntity<ZipCodeStats> getStats() {
-        ZipCodeStats stats = zipCodeService.getStatistics();
-        return ResponseEntity.ok(stats);
+        return ResponseEntity.ok(zipCodeService.getStatistics());
     }
 
-    @Operation(
-            summary = "🔎 Búsqueda parcial de código postal",
-            description = """
-                    Busca códigos postales que inicien con el prefijo proporcionado.
-                    Ideal para implementar autocompletado.
-
-                    ### Características:
-                    - ✅ Búsqueda por prefijo (ej: "010" encuentra "01000", "01010", etc.)
-                    - ✅ Límite configurable de resultados
-                    - ✅ Resultados ordenados numéricamente
-
-                    ### Ejemplos:
-                    - `/zip-codes/search?code=010&limit=5` - Primeros 5 códigos que inician con "010"
-                    - `/zip-codes/search?code=44` - Códigos de Jalisco (inician con 44)
-                    """,
-            tags = {"Búsqueda Directa"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "Códigos postales encontrados",
-                    content = @Content(mediaType = "application/json",
-                            array = @ArraySchema(schema = @Schema(implementation = ZipCode.class)))
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "Formato de código inválido",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "No se encontraron códigos postales",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            )
-    })
-    @GetMapping("/search")
-    public ResponseEntity<?> searchByPartialCode(
-            @Parameter(
-                    description = "Código postal parcial (solo dígitos)",
-                    required = true,
-                    example = "010"
-            )
-            @RequestParam("code")
-            @NotBlank(message = "El código no puede estar vacío")
-            @Pattern(regexp = "\\d{1,5}", message = "El código debe contener de 1 a 5 dígitos")
-            String code,
-
-            @Parameter(description = "Número máximo de resultados (1-50)")
-            @RequestParam(value = "limit", defaultValue = "10")
-            @Min(value = 1, message = "El límite debe ser mayor a 0")
-            @Max(value = 50, message = "El límite máximo es 50")
-            int limit,
-
-            @Parameter(description = "Si es true, devuelve formato simplificado")
-            @RequestParam(value = "simplified", defaultValue = "false")
-            boolean simplified
-    ) {
+    @Override
+    public ResponseEntity<?> searchByPartialCode(String code, int limit, boolean simplified) {
         List<ZipCode> results = zipCodeService.searchByPartialCode(code, limit);
-
         if (simplified) {
-            List<ZipCodeSimplified> simplifiedResults = results.stream()
+            return ResponseEntity.ok(results.stream()
                     .map(ZipCodeSimplified::fromZipCode)
-                    .toList();
-            return ResponseEntity.ok(simplifiedResults);
+                    .toList());
         }
-
         return ResponseEntity.ok(results);
     }
 
-    @Operation(
-            summary = "🗺️ Listar todas las entidades federativas",
-            description = """
-                    Obtiene la lista completa de las 32 entidades federativas (estados) de México.
-
-                    ### Información incluida:
-                    - Nombre del estado
-                    - Total de códigos postales
-                    - Total de municipios
-
-                    ### Uso:
-                    Útil para poblar selectores de estados en formularios o para conocer la cobertura por estado.
-                    """,
-            tags = {"Catálogos"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "Lista de entidades federativas",
-                    content = @Content(mediaType = "application/json",
-                            array = @ArraySchema(schema = @Schema(implementation = FederalEntity.class)))
-            )
-    })
-    @GetMapping("/federal-entities")
+    @Override
     public ResponseEntity<List<FederalEntity>> getAllFederalEntities() {
-        List<FederalEntity> entities = zipCodeService.getAllFederalEntities();
-        return ResponseEntity.ok(entities);
+        return ResponseEntity.ok(zipCodeService.getAllFederalEntities());
     }
 
-    @Operation(
-            summary = "🏙️ Listar municipios por entidad federativa",
-            description = """
-                    Obtiene la lista de municipios de una entidad federativa específica.
-
-                    ### Características:
-                    - ✅ Búsqueda parcial del nombre del estado
-                    - ✅ Insensible a acentos y mayúsculas
-                    - ✅ Resultados ordenados alfabéticamente
-
-                    ### Ejemplos:
-                    - `/zip-codes/federal-entities/jalisco/municipalities`
-                    - `/zip-codes/federal-entities/ciudad de mexico/municipalities`
-                    """,
-            tags = {"Catálogos"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "Lista de municipios",
-                    content = @Content(mediaType = "application/json",
-                            array = @ArraySchema(schema = @Schema(implementation = String.class)))
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "Entidad federativa no encontrada",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            )
-    })
-    @GetMapping("/federal-entities/{federalEntity}/municipalities")
-    public ResponseEntity<List<String>> getMunicipalitiesByFederalEntity(
-            @Parameter(
-                    description = "Nombre de la entidad federativa",
-                    required = true,
-                    example = "Jalisco"
-            )
-            @PathVariable("federalEntity")
-            @NotBlank(message = "La entidad federativa no puede estar vacía")
-            String federalEntity
-    ) {
-        List<String> municipalities = zipCodeService.getMunicipalitiesByFederalEntity(federalEntity);
-        return ResponseEntity.ok(municipalities);
+    @Override
+    public ResponseEntity<List<String>> getMunicipalitiesByFederalEntity(String federalEntity) {
+        return ResponseEntity.ok(zipCodeService.getMunicipalitiesByFederalEntity(federalEntity));
     }
 
-    @Operation(
-            summary = "🏘️ Obtener colonias por código postal",
-            description = """
-                    Obtiene la lista de colonias/asentamientos de un código postal específico.
-
-                    ### Información incluida por colonia:
-                    - Nombre del asentamiento
-                    - Tipo de asentamiento (Colonia, Fraccionamiento, etc.)
-                    - Tipo de zona (Urbano, Rural)
-
-                    ### Ejemplo:
-                    `/zip-codes/01000/settlements` - Colonias del CP 01000
-                    """,
-            tags = {"Búsqueda Directa"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "Lista de asentamientos",
-                    content = @Content(mediaType = "application/json",
-                            array = @ArraySchema(schema = @Schema(implementation = Settlements.class)))
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "Formato de código postal inválido",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "Código postal no encontrado",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            )
-    })
-    @GetMapping("/{zipcode}/settlements")
-    public ResponseEntity<List<Settlements>> getSettlementsByZipCode(
-            @Parameter(
-                    description = "El código postal",
-                    required = true,
-                    example = "01000"
-            )
-            @PathVariable("zipcode")
-            @Pattern(regexp = "\\d{5}", message = "El código postal debe tener exactamente 5 dígitos")
-            String zipcode
-    ) {
-        List<Settlements> settlements = zipCodeService.getSettlementsByZipCode(zipcode);
-        return ResponseEntity.ok(settlements);
+    @Override
+    public ResponseEntity<List<Settlements>> getSettlementsByZipCode(String zipcode) {
+        return ResponseEntity.ok(zipCodeService.getSettlementsByZipCode(zipcode));
     }
 
-    @Operation(
-            summary = "🔬 Búsqueda avanzada",
-            description = """
-                    Búsqueda con múltiples filtros combinados.
-
-                    ### Filtros disponibles:
-                    - `federal_entity` - Entidad federativa (estado)
-                    - `municipality` - Municipio
-                    - `settlement` - Nombre de colonia/asentamiento
-                    - `settlement_type` - Tipo de asentamiento (Colonia, Fraccionamiento, etc.)
-                    - `zone_type` - Tipo de zona (Urbano, Rural)
-
-                    ### Características:
-                    - ✅ Todos los filtros son opcionales (pero al menos uno requerido)
-                    - ✅ Búsqueda parcial en todos los campos
-                    - ✅ Insensible a acentos y mayúsculas
-                    - ✅ Paginación incluida
-                    - ✅ Opción de respuesta simplificada
-
-                    ### Ejemplo:
-                    Buscar colonias urbanas en Guadalajara:
-                    ```
-                    /zip-codes/advanced?federal_entity=jalisco&municipality=guadalajara&zone_type=urbano
-                    ```
-                    """,
-            tags = {"Búsqueda Avanzada"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "Códigos postales encontrados",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = PagedResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "Parámetros de búsqueda inválidos",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "No se encontraron resultados",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))
-            )
-    })
-    @GetMapping("/advanced")
+    @Override
     public ResponseEntity<?> advancedSearch(
-            @Parameter(description = "Entidad federativa (estado)")
-            @RequestParam(value = "federal_entity", required = false)
             String federalEntity,
-
-            @Parameter(description = "Municipio")
-            @RequestParam(value = "municipality", required = false)
             String municipality,
-
-            @Parameter(description = "Nombre de colonia/asentamiento")
-            @RequestParam(value = "settlement", required = false)
             String settlement,
-
-            @Parameter(description = "Tipo de asentamiento")
-            @RequestParam(value = "settlement_type", required = false)
             String settlementType,
-
-            @Parameter(description = "Tipo de zona (Urbano/Rural)")
-            @RequestParam(value = "zone_type", required = false)
             String zoneType,
-
-            @Parameter(description = "Número de página")
-            @RequestParam(value = "page", defaultValue = "0")
-            @Min(value = 0, message = "La página debe ser mayor o igual a 0")
-            @Max(value = 10_000, message = "El número de página es inválido")
             int page,
-
-            @Parameter(description = "Tamaño de página")
-            @RequestParam(value = "size", defaultValue = "20")
-            @Min(value = 1, message = "El tamaño debe ser mayor a 0")
-            @Max(value = 100, message = "El tamaño máximo es 100")
             int size,
+            boolean simplified) {
 
-            @Parameter(description = "Si es true, devuelve formato simplificado")
-            @RequestParam(value = "simplified", defaultValue = "false")
-            boolean simplified
-    ) {
         AdvancedSearchRequest request = AdvancedSearchRequest.builder()
                 .federalEntity(federalEntity)
                 .municipality(municipality)
                 .settlement(settlement)
                 .settlementType(settlementType)
                 .zoneType(zoneType)
-                .page(page)
-                .size(size)
-                .simplified(simplified)
                 .build();
 
         PagedResponse<ZipCode> response = zipCodeService.advancedSearch(request, page, size);

--- a/src/main/java/com/coderalexis/CodigoPostalApi/controller/ZipCodeApi.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/controller/ZipCodeApi.java
@@ -1,0 +1,314 @@
+package com.coderalexis.CodigoPostalApi.controller;
+
+import com.coderalexis.CodigoPostalApi.exceptions.ErrorResponse;
+import com.coderalexis.CodigoPostalApi.model.FederalEntity;
+import com.coderalexis.CodigoPostalApi.model.PagedResponse;
+import com.coderalexis.CodigoPostalApi.model.Settlements;
+import com.coderalexis.CodigoPostalApi.model.ZipCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+/**
+ * Contrato REST del API de códigos postales. Fix #16: extraer las anotaciones
+ * OpenAPI (que dominaban el archivo Controller.java) a esta interfaz deja la
+ * implementación enfocada en la lógica y permite documentar el contrato sin
+ * leer el código de los handlers. Spring procesa mapping y validation
+ * annotations declaradas en la interfaz tal como si estuvieran en la clase.
+ */
+@RequestMapping("/zip-codes")
+public interface ZipCodeApi {
+
+    @Operation(
+            summary = "🔍 Buscar código postal específico",
+            description = """
+                    Obtiene información completa de un código postal específico incluyendo:
+                    - Entidad federativa
+                    - Municipio
+                    - Localidad
+                    - Lista de asentamientos (colonias, fraccionamientos, etc.)
+
+                    ### Ejemplos de uso:
+                    - `01000` - San Ángel, Ciudad de México
+                    - `44100` - Guadalajara Centro, Jalisco
+                    - `64000` - Monterrey Centro, Nuevo León
+
+                    ### Rendimiento:
+                    Este endpoint está optimizado con caché, tiempo de respuesta típico: **~50ms**
+                    """,
+            tags = {"Búsqueda Directa"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Código postal encontrado",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ZipCode.class))),
+            @ApiResponse(responseCode = "400", description = "Formato de código postal inválido",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Código postal no encontrado",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{zipcode}")
+    ResponseEntity<ZipCode> getZipCode(
+            @Parameter(description = "El código postal a buscar", required = true, example = "01000")
+            @PathVariable("zipcode")
+            @Pattern(regexp = "\\d{5}", message = "El código postal debe tener exactamente 5 dígitos")
+            String zipcode
+    );
+
+    @Operation(
+            summary = "🗺️ Buscar por entidad federativa (estado)",
+            description = """
+                    Busca códigos postales por entidad federativa con paginación automática.
+
+                    ### Características:
+                    - ✅ Búsqueda parcial (ej: "mex" encuentra "México", "Nuevo México")
+                    - ✅ Insensible a acentos ("Mexico" = "México")
+                    - ✅ Insensible a mayúsculas
+                    - ✅ Resultados paginados
+                    """,
+            tags = {"Búsqueda por Ubicación"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista de códigos postales que coinciden",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = PagedResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Parámetros de búsqueda inválidos",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "No se encontraron códigos postales",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping
+    ResponseEntity<PagedResponse<ZipCode>> searchByFederalEntity(
+            @Parameter(description = "Término de búsqueda para la entidad federativa (puede ser parcial)",
+                    required = true, example = "mexico")
+            @RequestParam("federal_entity")
+            @NotBlank(message = "El término de búsqueda no puede estar vacío")
+            String federalEntity,
+
+            @Parameter(description = "Número de página (comienza en 0)")
+            @RequestParam(value = "page", defaultValue = "0")
+            @Min(value = 0, message = "La página debe ser mayor o igual a 0")
+            @Max(value = 10_000, message = "El número de página es inválido")
+            int page,
+
+            @Parameter(description = "Tamaño de página")
+            @RequestParam(value = "size", defaultValue = "20")
+            @Min(value = 1, message = "El tamaño debe ser mayor a 0")
+            @Max(value = 100, message = "El tamaño máximo es 100")
+            int size
+    );
+
+    @Operation(
+            summary = "🏘️ Buscar por municipio",
+            description = """
+                    Busca códigos postales por municipio con paginación.
+
+                    ### Características:
+                    - ✅ Búsqueda parcial
+                    - ✅ Insensible a acentos y mayúsculas
+                    - ✅ Resultados paginados
+                    """,
+            tags = {"Búsqueda por Ubicación"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista de códigos postales que coinciden con el municipio",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = PagedResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Parámetros de búsqueda inválidos",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "No se encontraron códigos postales",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/by-municipality")
+    ResponseEntity<PagedResponse<ZipCode>> searchByMunicipality(
+            @Parameter(description = "Término de búsqueda para el municipio (puede ser parcial)",
+                    required = true, example = "Guadalajara")
+            @RequestParam("municipality")
+            @NotBlank(message = "El municipio no puede estar vacío")
+            String municipality,
+
+            @Parameter(description = "Número de página (comienza en 0)")
+            @RequestParam(value = "page", defaultValue = "0")
+            @Min(value = 0, message = "La página debe ser mayor o igual a 0")
+            @Max(value = 10_000, message = "El número de página es inválido")
+            int page,
+
+            @Parameter(description = "Tamaño de página")
+            @RequestParam(value = "size", defaultValue = "20")
+            @Min(value = 1, message = "El tamaño debe ser mayor a 0")
+            @Max(value = 100, message = "El tamaño máximo es 100")
+            int size
+    );
+
+    @Operation(
+            summary = "📊 Estadísticas generales",
+            description = "Obtiene estadísticas sobre el catálogo completo de códigos postales.",
+            tags = {"Estadísticas"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Estadísticas obtenidas exitosamente",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.coderalexis.CodigoPostalApi.model.ZipCodeStats.class)))
+    })
+    @GetMapping("/stats")
+    ResponseEntity<com.coderalexis.CodigoPostalApi.model.ZipCodeStats> getStats();
+
+    @Operation(
+            summary = "🔎 Búsqueda parcial de código postal",
+            description = """
+                    Busca códigos postales que inicien con el prefijo proporcionado.
+                    Ideal para implementar autocompletado.
+                    """,
+            tags = {"Búsqueda Directa"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Códigos postales encontrados",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = ZipCode.class)))),
+            @ApiResponse(responseCode = "400", description = "Formato de código inválido",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "No se encontraron códigos postales",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/search")
+    ResponseEntity<?> searchByPartialCode(
+            @Parameter(description = "Código postal parcial (solo dígitos)", required = true, example = "010")
+            @RequestParam("code")
+            @NotBlank(message = "El código no puede estar vacío")
+            @Pattern(regexp = "\\d{1,5}", message = "El código debe contener de 1 a 5 dígitos")
+            String code,
+
+            @Parameter(description = "Número máximo de resultados (1-50)")
+            @RequestParam(value = "limit", defaultValue = "10")
+            @Min(value = 1, message = "El límite debe ser mayor a 0")
+            @Max(value = 50, message = "El límite máximo es 50")
+            int limit,
+
+            @Parameter(description = "Si es true, devuelve formato simplificado")
+            @RequestParam(value = "simplified", defaultValue = "false")
+            boolean simplified
+    );
+
+    @Operation(
+            summary = "🗺️ Listar todas las entidades federativas",
+            description = "Obtiene la lista completa de las 32 entidades federativas (estados) de México.",
+            tags = {"Catálogos"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista de entidades federativas",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = FederalEntity.class))))
+    })
+    @GetMapping("/federal-entities")
+    ResponseEntity<List<FederalEntity>> getAllFederalEntities();
+
+    @Operation(
+            summary = "🏙️ Listar municipios por entidad federativa",
+            description = "Obtiene la lista de municipios de una entidad federativa específica.",
+            tags = {"Catálogos"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista de municipios",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = String.class)))),
+            @ApiResponse(responseCode = "404", description = "Entidad federativa no encontrada",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/federal-entities/{federalEntity}/municipalities")
+    ResponseEntity<List<String>> getMunicipalitiesByFederalEntity(
+            @Parameter(description = "Nombre de la entidad federativa", required = true, example = "Jalisco")
+            @PathVariable("federalEntity")
+            @NotBlank(message = "La entidad federativa no puede estar vacía")
+            String federalEntity
+    );
+
+    @Operation(
+            summary = "🏘️ Obtener colonias por código postal",
+            description = "Obtiene la lista de colonias/asentamientos de un código postal específico.",
+            tags = {"Búsqueda Directa"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista de asentamientos",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = Settlements.class)))),
+            @ApiResponse(responseCode = "400", description = "Formato de código postal inválido",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Código postal no encontrado",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{zipcode}/settlements")
+    ResponseEntity<List<Settlements>> getSettlementsByZipCode(
+            @Parameter(description = "El código postal", required = true, example = "01000")
+            @PathVariable("zipcode")
+            @Pattern(regexp = "\\d{5}", message = "El código postal debe tener exactamente 5 dígitos")
+            String zipcode
+    );
+
+    @Operation(
+            summary = "🔬 Búsqueda avanzada",
+            description = """
+                    Búsqueda con múltiples filtros combinados.
+
+                    ### Filtros disponibles:
+                    - `federal_entity` - Entidad federativa (estado)
+                    - `municipality` - Municipio
+                    - `settlement` - Nombre de colonia/asentamiento
+                    - `settlement_type` - Tipo de asentamiento (Colonia, Fraccionamiento, etc.)
+                    - `zone_type` - Tipo de zona (Urbano, Rural)
+                    """,
+            tags = {"Búsqueda Avanzada"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Códigos postales encontrados",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = PagedResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Parámetros de búsqueda inválidos",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "No se encontraron resultados",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/advanced")
+    ResponseEntity<?> advancedSearch(
+            @Parameter(description = "Entidad federativa (estado)")
+            @RequestParam(value = "federal_entity", required = false) String federalEntity,
+
+            @Parameter(description = "Municipio")
+            @RequestParam(value = "municipality", required = false) String municipality,
+
+            @Parameter(description = "Nombre de colonia/asentamiento")
+            @RequestParam(value = "settlement", required = false) String settlement,
+
+            @Parameter(description = "Tipo de asentamiento")
+            @RequestParam(value = "settlement_type", required = false) String settlementType,
+
+            @Parameter(description = "Tipo de zona (Urbano/Rural)")
+            @RequestParam(value = "zone_type", required = false) String zoneType,
+
+            @Parameter(description = "Número de página")
+            @RequestParam(value = "page", defaultValue = "0")
+            @Min(value = 0, message = "La página debe ser mayor o igual a 0")
+            @Max(value = 10_000, message = "El número de página es inválido")
+            int page,
+
+            @Parameter(description = "Tamaño de página")
+            @RequestParam(value = "size", defaultValue = "20")
+            @Min(value = 1, message = "El tamaño debe ser mayor a 0")
+            @Max(value = 100, message = "El tamaño máximo es 100")
+            int size,
+
+            @Parameter(description = "Si es true, devuelve formato simplificado")
+            @RequestParam(value = "simplified", defaultValue = "false")
+            boolean simplified
+    );
+}

--- a/src/main/java/com/coderalexis/CodigoPostalApi/model/AdvancedSearchRequest.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/model/AdvancedSearchRequest.java
@@ -3,15 +3,17 @@ package com.coderalexis.CodigoPostalApi.model;
 import com.coderalexis.CodigoPostalApi.util.Util;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * Request para búsqueda avanzada con múltiples filtros.
+ * DTO con los filtros lógicos de la búsqueda avanzada. Sólo contiene los
+ * criterios de filtrado; la paginación y el formato de respuesta se reciben
+ * como parámetros separados del controlador para evitar duplicar
+ * representaciones y reducir el riesgo de discrepancia entre el query string
+ * y el cuerpo del request.
  */
 @Data
 @Builder
@@ -38,25 +40,10 @@ public class AdvancedSearchRequest {
     @JsonProperty("zone_type")
     private String zoneType;
 
-    @Schema(description = "Número de página (comienza en 0)", example = "0")
-    @Min(value = 0, message = "La página debe ser mayor o igual a 0")
-    @Builder.Default
-    private int page = 0;
-
-    @Schema(description = "Tamaño de página", example = "20")
-    @Min(value = 1, message = "El tamaño debe ser mayor a 0")
-    @Max(value = 100, message = "El tamaño máximo es 100")
-    @Builder.Default
-    private int size = 20;
-
-    @Schema(description = "Si es true, devuelve formato simplificado sin lista de asentamientos", example = "false")
-    @Builder.Default
-    private boolean simplified = false;
-
     /**
-     * Stable cache key for the expensive, unpaged advanced-search result set.
-     * Page, size, and simplified are intentionally excluded because pagination
-     * and presentation mapping are applied after retrieving the full result list.
+     * Cache key estable basada exclusivamente en los filtros normalizados.
+     * Por diseño no incluye paginación ni formato porque ambos se aplican a
+     * posteriori sobre el conjunto de resultados.
      */
     public String normalizedFilterCacheKey() {
         return String.join("|",
@@ -65,5 +52,23 @@ public class AdvancedSearchRequest {
                 Util.normalizeCacheKey(settlement),
                 Util.normalizeCacheKey(settlementType),
                 Util.normalizeCacheKey(zoneType));
+    }
+
+    /**
+     * Indica si el request tiene al menos un filtro útil. Usado por las
+     * condiciones SpEL de {@code @Cacheable} para evitar entrar al cache con
+     * requests inválidos que de todas formas terminarán en
+     * IllegalArgumentException (#19).
+     */
+    public boolean hasAnyFilter() {
+        return notBlank(federalEntity)
+                || notBlank(municipality)
+                || notBlank(settlement)
+                || notBlank(settlementType)
+                || notBlank(zoneType);
+    }
+
+    private static boolean notBlank(String s) {
+        return s != null && !s.isBlank();
     }
 }

--- a/src/main/java/com/coderalexis/CodigoPostalApi/model/Settlements.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/model/Settlements.java
@@ -2,30 +2,23 @@ package com.coderalexis.CodigoPostalApi.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-import java.io.Serializable;
-
-@Data
-@NoArgsConstructor
-public class Settlements implements Serializable {
-    private static final long serialVersionUID = 1L;
-
-    private String name;
-
-    @JsonProperty("zone_type")
-    private String zoneType;
-
-    @JsonProperty("settlement_type")
-    private String settlementType;
-
-    @JsonIgnore
-    private String normalizedName;
-
-    @JsonIgnore
-    private String normalizedSettlementType;
-
-    @JsonIgnore
-    private String normalizedZoneType;
+/**
+ * Representa un asentamiento (colonia, fraccionamiento, etc.) dentro de un
+ * código postal. Se convirtió a record porque conceptualmente es un valor
+ * inmutable: una vez cargado desde SEPOMEX al arrancar, sus campos no cambian.
+ *
+ * <p>Los campos {@code normalized*} se calculan una sola vez durante la carga
+ * y se usan en el hot path de búsqueda avanzada para evitar reentrar a
+ * {@link com.coderalexis.CodigoPostalApi.util.Util#normalizeString(String)}
+ * en cada filtro.</p>
+ */
+public record Settlements(
+        String name,
+        @JsonProperty("zone_type") String zoneType,
+        @JsonProperty("settlement_type") String settlementType,
+        @JsonIgnore String normalizedName,
+        @JsonIgnore String normalizedSettlementType,
+        @JsonIgnore String normalizedZoneType
+) {
 }

--- a/src/main/java/com/coderalexis/CodigoPostalApi/model/ZipCode.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/model/ZipCode.java
@@ -1,7 +1,6 @@
 package com.coderalexis.CodigoPostalApi.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -11,12 +10,16 @@ import lombok.ToString;
 
 import java.util.List;
 
+/**
+ * NOTA sobre @JsonInclude: la inclusión NON_NULL ya está configurada
+ * globalmente en application.yml (spring.jackson.default-property-inclusion),
+ * así que no hace falta repetirla aquí.
+ */
 @Getter
 @Setter
 @ToString
 @NoArgsConstructor
 @EqualsAndHashCode(of = "zipCode")
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ZipCode {
     @JsonProperty("zip_code")
     private String zipCode;

--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
@@ -9,24 +9,42 @@ import com.coderalexis.CodigoPostalApi.model.Settlements;
 import com.coderalexis.CodigoPostalApi.model.ZipCode;
 import com.coderalexis.CodigoPostalApi.model.ZipCodeStats;
 import com.coderalexis.CodigoPostalApi.util.Util;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.stereotype.Service;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
-import java.util.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.Collection;
-import java.util.List;
-import java.util.function.Predicate;
 
 @Service
 @Slf4j
@@ -44,6 +62,7 @@ public class ZipCodeService {
     private static final int COL_ZONE_TYPE_INDEX = 13;
     private static final int MIN_COLUMNS = 6;
     private static final int MAX_ERRORS_THRESHOLD = 100;
+    private static final int PARTIAL_SEARCH_MAX_LIMIT = 50;
 
     private static final Pattern ZIP_CODE_PATTERN =
         Pattern.compile("^\\d{5}$");
@@ -63,6 +82,23 @@ public class ZipCodeService {
     private volatile ZipCodeStats cachedStats;
     // Pre-computed federal entities list (immutable after load)
     private volatile List<FederalEntity> cachedFederalEntities;
+    // Pre-computed map: normalized entity key -> sorted set of municipalities (original case)
+    // Avoids re-iterating zipcode -> distinct municipality each call.
+    private volatile Map<String, Set<String>> municipalitiesByNormalizedEntity;
+
+    /**
+     * Cache directo para búsquedas por prefijo. Se usa Caffeine en vez de
+     * {@code @Cacheable} para evitar la trampa de self-invocation (Spring sólo
+     * intercepta las llamadas entre beans, no entre métodos de la misma clase).
+     * El cache se llava sólo por prefijo y guarda hasta
+     * {@link #PARTIAL_SEARCH_MAX_LIMIT} ZipCodes; el {@code limit} del request
+     * se aplica al leer. Fix #5.
+     */
+    private final Cache<String, List<ZipCode>> partialPrefixCache = Caffeine.newBuilder()
+            .maximumSize(500)
+            .expireAfterWrite(10, TimeUnit.MINUTES)
+            .recordStats()
+            .build();
 
     private volatile boolean dataLoaded = false;
     private int errorCount = 0;
@@ -113,25 +149,39 @@ public class ZipCodeService {
 
             processZipCodeFile(stream);
             buildPreComputedData();
-
+            // Fix #2: marcamos dataLoaded sólo DESPUÉS de que las estructuras
+            // precomputadas (cachedStats, cachedFederalEntities,
+            // municipalitiesByNormalizedEntity) estén completas. De lo contrario
+            // un caller temprano podría ver dataLoaded=true pero campos null.
+            dataLoaded = true;
         } catch (IOException e) {
             log.error("Error al cargar los codigos postales", e);
         }
     }
 
     private void buildPreComputedData() {
-        // Make all settlement lists immutable to prevent accidental mutation of internal state
+        // Make all settlement lists immutable to prevent accidental mutation of internal state.
+        // Single pass (#10): durante esta pasada también acumulamos totalSettlements
+        // y la lista de FederalEntity para evitar recorrer el mapa varias veces.
+        long totalSettlements = 0L;
+        Map<String, List<ZipCode>> zipCodesByEntity = new HashMap<>();
+        Map<String, Set<String>> municipalitiesByEntity = new HashMap<>();
+
         for (ZipCode zc : zipCodesByCode.values()) {
             if (zc.getSettlements() != null) {
                 zc.setSettlements(List.copyOf(zc.getSettlements()));
+                totalSettlements += zc.getSettlements().size();
             }
+
+            zipCodesByEntity
+                    .computeIfAbsent(zc.getFederalEntity(), k -> new ArrayList<>())
+                    .add(zc);
+
+            municipalitiesByEntity
+                    .computeIfAbsent(zc.getNormalizedFederalEntity(), k -> new TreeSet<>())
+                    .add(zc.getMunicipality());
         }
         log.info("  - Listas de asentamientos convertidas a inmutables");
-
-        // Pre-compute statistics once (data is immutable after load)
-        long totalSettlements = zipCodesByCode.values().stream()
-                .mapToLong(zc -> zc.getSettlements().size())
-                .sum();
 
         cachedStats = ZipCodeStats.builder()
                 .totalZipCodes(zipCodesByCode.size())
@@ -139,10 +189,6 @@ public class ZipCodeService {
                 .totalMunicipalities(zipCodesByNormalizedMunicipality.size())
                 .totalSettlements(totalSettlements)
                 .build();
-
-        // Pre-compute federal entities list
-        Map<String, List<ZipCode>> zipCodesByEntity = zipCodesByCode.values().stream()
-                .collect(Collectors.groupingBy(ZipCode::getFederalEntity));
 
         cachedFederalEntities = zipCodesByEntity.entrySet().stream()
                 .map(entry -> {
@@ -163,26 +209,46 @@ public class ZipCodeService {
                 .sorted(Comparator.comparing(FederalEntity::getName))
                 .toList();
 
-        log.info("  - Estadisticas y entidades federativas pre-computadas");
+        // Snapshot inmutable para lecturas concurrentes (#9).
+        Map<String, Set<String>> immutable = new HashMap<>(municipalitiesByEntity.size());
+        for (Map.Entry<String, Set<String>> e : municipalitiesByEntity.entrySet()) {
+            immutable.put(e.getKey(), Collections.unmodifiableSortedSet((TreeSet<String>) e.getValue()));
+        }
+        this.municipalitiesByNormalizedEntity = Collections.unmodifiableMap(immutable);
+
+        log.info("  - Estadisticas, entidades federativas y municipios precomputados");
     }
 
+    /**
+     * Resuelve el InputStream del catálogo SEPOMEX.
+     *
+     * <p>Fix #20: si el usuario configura un path explícito (vía
+     * {@code zipcode.file.path}) y éste no existe, fallamos rápido en vez de
+     * caer silenciosamente al recurso interno, que enmascaraba problemas de
+     * despliegue (config incorrecta sin error visible).</p>
+     */
     private InputStream getInputStream() throws IOException {
-        if (filePath != null && filePath.startsWith("classpath:")) {
+        boolean userConfiguredPath = filePath != null && !filePath.isBlank();
+
+        if (userConfiguredPath && filePath.startsWith("classpath:")) {
             String resourcePath = filePath.substring("classpath:".length());
             ClassPathResource resource = new ClassPathResource(resourcePath);
             if (resource.exists()) {
                 log.info("Cargando codigos postales desde classpath: {}", resourcePath);
                 return resource.getInputStream();
             }
-            log.warn("Recurso no encontrado en classpath: {}", resourcePath);
+            throw new IOException(
+                "Recurso configurado en 'zipcode.file.path' no encontrado en classpath: " + resourcePath);
         }
 
-        if (filePath != null && !filePath.startsWith("classpath:")) {
+        if (userConfiguredPath) {
             Path path = Paths.get(filePath);
             if (Files.exists(path)) {
                 log.info("Cargando codigos postales desde {}", filePath);
                 return Files.newInputStream(path);
             }
+            throw new IOException(
+                "Archivo configurado en 'zipcode.file.path' no encontrado: " + filePath);
         }
 
         ClassPathResource resource = new ClassPathResource(RESOURCE_FILE);
@@ -214,7 +280,6 @@ public class ZipCodeService {
                     .count();
 
             long duration = System.currentTimeMillis() - startTime;
-            dataLoaded = true;
 
             log.info("Datos cargados exitosamente en {}ms", duration);
             log.info("  - Codigos postales unicos: {}", zipCodesByCode.size());
@@ -310,20 +375,20 @@ public class ZipCodeService {
                 return z;
             });
 
-            Settlements settlement = new Settlements();
             String settlementName = words[COL_SETTLEMENT_NAME].trim();
             String settlementTypeVal = words[COL_SETTLEMENT_TYPE].trim();
             String zoneTypeVal = words.length > COL_ZONE_TYPE_INDEX ?
                 words[COL_ZONE_TYPE_INDEX].trim() : "";
-            
-            settlement.setName(settlementName);
-            settlement.setZoneType(zoneTypeVal);
-            settlement.setSettlementType(settlementTypeVal);
-            
-            // Pre-compute normalized fields to avoid runtime normalization in searches
-            settlement.setNormalizedName(Util.normalizeString(settlementName));
-            settlement.setNormalizedSettlementType(Util.normalizeString(settlementTypeVal));
-            settlement.setNormalizedZoneType(Util.normalizeString(zoneTypeVal));
+
+            // Fix #18: Settlements ahora es un record inmutable, construido en una
+            // sola expresión con los campos normalizados precomputados.
+            Settlements settlement = new Settlements(
+                    settlementName,
+                    zoneTypeVal,
+                    settlementTypeVal,
+                    Util.normalizeString(settlementName),
+                    Util.normalizeString(settlementTypeVal),
+                    Util.normalizeString(zoneTypeVal));
 
             zipCode.getSettlements().add(settlement);
 
@@ -358,6 +423,13 @@ public class ZipCodeService {
         return zipCode != null && ZIP_CODE_PATTERN.matcher(zipCode).matches();
     }
 
+    /**
+     * @deprecated Usar la variante paginada {@link #searchByFederalEntity(String, int, int)}.
+     * Este método materializa todos los ZipCodes coincidentes (que para una entidad como
+     * "Ciudad de México" pueden ser ≥25 000) y los retiene en cache; el controlador
+     * siempre llama a la versión paginada. Se mantiene sólo por compatibilidad de tests.
+     */
+    @Deprecated(forRemoval = false)
     @Cacheable(value = "federalEntitySearch", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#searchTerm)")
     public List<ZipCode> searchByFederalEntity(String searchTerm) {
         Timer.Sample sample = metricsConfiguration.startTimer();
@@ -384,8 +456,9 @@ public class ZipCodeService {
     }
 
     /**
-     * Paginated search by federal entity.
-     * Counts matches and materializes only the requested page in zip-code order.
+     * Búsqueda paginada por entidad federativa. Fix #8: ordena el conjunto
+     * (vía índice invertido) y materializa sólo la página solicitada en vez
+     * de la lista completa.
      */
     @Cacheable(value = "federalEntitySearchPaged", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#searchTerm) + '_' + #page + '_' + #size")
     public PagedResponse<ZipCode> searchByFederalEntity(String searchTerm, int page, int size) {
@@ -395,17 +468,19 @@ public class ZipCodeService {
             validatePagination(page, size);
             String normalizedSearchTerm = validateSearchTerm(searchTerm, "federal_entity");
 
-            List<ZipCode> candidates = findOrderedCandidatesInIndex(
-                    zipCodesByNormalizedEntity,
-                    normalizedSearchTerm);
-            PagedResponse<ZipCode> response = createPagedResponse(candidates, page, size);
-
-            if (response.getTotalElements() == 0) {
+            Set<ZipCode> matches = findCandidatesInIndex(zipCodesByNormalizedEntity, normalizedSearchTerm);
+            if (matches.isEmpty()) {
                 metricsConfiguration.recordSearchError("federal_entity", "not_found");
                 throw new ZipCodeNotFoundException(
                         "No se encontraron codigos postales para la entidad federativa: " + searchTerm
                 );
             }
+
+            PagedResponse<ZipCode> response = paginateSorted(
+                    matches,
+                    Comparator.comparing(ZipCode::getZipCode),
+                    page,
+                    size);
 
             metricsConfiguration.recordResultSize("federal_entity", (int) response.getTotalElements());
             return response;
@@ -414,6 +489,10 @@ public class ZipCodeService {
         }
     }
 
+    /**
+     * @deprecated Usar la variante paginada {@link #searchByMunicipality(String, int, int)}.
+     */
+    @Deprecated(forRemoval = false)
     @Cacheable(value = "municipalitySearch", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#searchTerm)")
     public List<ZipCode> searchByMunicipality(String searchTerm) {
         Timer.Sample sample = metricsConfiguration.startTimer();
@@ -440,8 +519,7 @@ public class ZipCodeService {
     }
 
     /**
-     * Paginated search by municipality.
-     * Counts matches and materializes only the requested page in zip-code order.
+     * Búsqueda paginada por municipio. Fix #8: idem entidad federativa.
      */
     @Cacheable(value = "municipalitySearchPaged", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#searchTerm) + '_' + #page + '_' + #size")
     public PagedResponse<ZipCode> searchByMunicipality(String searchTerm, int page, int size) {
@@ -451,17 +529,19 @@ public class ZipCodeService {
             validatePagination(page, size);
             String normalizedSearchTerm = validateSearchTerm(searchTerm, "municipality");
 
-            List<ZipCode> candidates = findOrderedCandidatesInIndex(
-                    zipCodesByNormalizedMunicipality,
-                    normalizedSearchTerm);
-            PagedResponse<ZipCode> response = createPagedResponse(candidates, page, size);
-
-            if (response.getTotalElements() == 0) {
+            Set<ZipCode> matches = findCandidatesInIndex(zipCodesByNormalizedMunicipality, normalizedSearchTerm);
+            if (matches.isEmpty()) {
                 metricsConfiguration.recordSearchError("municipality", "not_found");
                 throw new ZipCodeNotFoundException(
                         "No se encontraron codigos postales para el municipio: " + searchTerm
                 );
             }
+
+            PagedResponse<ZipCode> response = paginateSorted(
+                    matches,
+                    Comparator.comparing(ZipCode::getZipCode),
+                    page,
+                    size);
 
             metricsConfiguration.recordResultSize("municipality", (int) response.getTotalElements());
             return response;
@@ -479,13 +559,13 @@ public class ZipCodeService {
 
     /**
      * Prefix search using ConcurrentSkipListMap.subMap() for O(log n + k) performance.
-     * Uses exclusive upper bound with incremented prefix for correct range matching.
-     * 
-     * For example, prefix "019" matches codes in range ["01900", "01999"].
-     * The upper bound is computed by incrementing the last character: "019" -> "020",
-     * then using subMap("019", "020") which gives us all codes starting with "019".
+     *
+     * <p>Fix #5: la cache ahora se llava SÓLO por el prefijo normalizado. Para
+     * cada prefijo cacheamos hasta {@link #PARTIAL_SEARCH_MAX_LIMIT} resultados
+     * y aplicamos el {@code limit} solicitado tras leer del cache; esto evita
+     * que un cliente que pida limit=1,2,...,50 con el mismo prefijo agote la
+     * cache con 50 entradas equivalentes.</p>
      */
-    @Cacheable(value = "partialSearch", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#partialCode) + '_' + #limit")
     public List<ZipCode> searchByPartialCode(String partialCode, int limit) {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
@@ -503,31 +583,40 @@ public class ZipCodeService {
                 throw new IllegalArgumentException("El codigo postal debe contener entre 1 y 5 digitos");
             }
 
-            int effectiveLimit = Math.min(Math.max(limit, 1), 50);
+            int effectiveLimit = Math.min(Math.max(limit, 1), PARTIAL_SEARCH_MAX_LIMIT);
+            List<ZipCode> cached = partialPrefixCache.get(cleanCode, this::computePartialPrefix);
 
-            // O(log n + k) using sorted map range query.
-            // The exclusive upper bound stays inside the requested prefix, so a search
-            // like "0199" never leaks "020xx" rows.
-            String fromKey = cleanCode;
-            String toKey = computeUpperBound(cleanCode);
-
-            List<ZipCode> results = zipCodesSorted.subMap(fromKey, true, toKey, false)
-                    .values().stream()
-                    .limit(effectiveLimit)
-                    .collect(Collectors.toList());
-
-            if (results.isEmpty()) {
+            if (cached.isEmpty()) {
                 metricsConfiguration.recordSearchError("partial", "not_found");
                 throw new ZipCodeNotFoundException(
                         "No se encontraron codigos postales que inicien con: " + partialCode
                 );
             }
 
-            metricsConfiguration.recordResultSize("partial", results.size());
-            return results;
+            List<ZipCode> limited = cached.size() <= effectiveLimit
+                    ? cached
+                    : cached.subList(0, effectiveLimit);
+
+            metricsConfiguration.recordResultSize("partial", limited.size());
+            return limited;
         } finally {
             metricsConfiguration.recordSearchDuration(sample, "partial");
         }
+    }
+
+    /**
+     * Calcula los resultados para un prefijo concreto, limitando a
+     * {@link #PARTIAL_SEARCH_MAX_LIMIT} para que el cache tenga un tamaño
+     * predecible por entrada.
+     */
+    private List<ZipCode> computePartialPrefix(String prefix) {
+        // El exclusive upper bound se queda dentro del prefijo solicitado para que
+        // una búsqueda como "0199" no incluya "020xx".
+        String toKey = computeUpperBound(prefix);
+        return zipCodesSorted.subMap(prefix, true, toKey, false)
+                .values().stream()
+                .limit(PARTIAL_SEARCH_MAX_LIMIT)
+                .toList();
     }
 
     /**
@@ -535,7 +624,7 @@ public class ZipCodeService {
      *
      * Appending the maximum Unicode character creates a key that is greater than
      * every digit-only zip code that starts with the requested prefix, without
-     * including the next numeric range. For example, range ["0199", "0199\uFFFF")
+     * including the next numeric range. For example, range ["0199", "0199￿")
      * includes "01990" through "01999" but excludes "02000".
      */
     private String computeUpperBound(String prefix) {
@@ -556,6 +645,11 @@ public class ZipCodeService {
         }
     }
 
+    /**
+     * Fix #9: utiliza el índice precomputado {@code municipalitiesByNormalizedEntity}.
+     * Para "mex" matchea ~3 entidades grandes y une sus sets ya ordenados, sin
+     * recorrer decenas de miles de ZipCodes para hacer {@code distinct()}.
+     */
     @Cacheable(value = "municipalitiesByEntity", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#federalEntity)")
     public List<String> getMunicipalitiesByFederalEntity(String federalEntity) {
         Timer.Sample sample = metricsConfiguration.startTimer();
@@ -566,14 +660,13 @@ public class ZipCodeService {
 
             String normalizedSearchTerm = Util.normalizeSearchTerm(federalEntity);
 
-            // Sequential stream - only ~32 entity keys to filter
-            List<String> municipalities = zipCodesByNormalizedEntity.entrySet().stream()
-                    .filter(entry -> entry.getKey().contains(normalizedSearchTerm))
-                    .flatMap(entry -> entry.getValue().stream())
-                    .map(ZipCode::getMunicipality)
-                    .distinct()
-                    .sorted()
-                    .collect(Collectors.toList());
+            // TreeSet para mantener orden alfabético al unir municipios de varias entidades.
+            Set<String> municipalities = new TreeSet<>();
+            for (Map.Entry<String, Set<String>> entry : municipalitiesByNormalizedEntity.entrySet()) {
+                if (entry.getKey().contains(normalizedSearchTerm)) {
+                    municipalities.addAll(entry.getValue());
+                }
+            }
 
             if (municipalities.isEmpty()) {
                 throw new ZipCodeNotFoundException(
@@ -582,7 +675,7 @@ public class ZipCodeService {
             }
 
             metricsConfiguration.recordResultSize("municipalities_by_entity", municipalities.size());
-            return municipalities;
+            return List.copyOf(municipalities);
         } finally {
             metricsConfiguration.recordSearchDuration(sample, "municipalities_by_entity");
         }
@@ -594,10 +687,16 @@ public class ZipCodeService {
     }
 
     /**
-     * Advanced search using inverted indices as starting point when possible.
-     * Uses pre-computed normalized fields to avoid runtime normalization.
+     * @deprecated Usar la variante paginada {@link #advancedSearch(AdvancedSearchRequest, int, int)}.
+     * Materializar toda la lista en cache puede tener un costo de memoria significativo.
      */
-    @Cacheable(value = "advancedSearch", key = "#request == null ? 'null' : #request.normalizedFilterCacheKey()")
+    @Deprecated(forRemoval = false)
+    @Cacheable(
+            value = "advancedSearch",
+            key = "#request.normalizedFilterCacheKey()",
+            // Fix #19: evita ocupar slot de cache con requests inválidos (null o
+            // todos los filtros vacíos) que terminarán en IllegalArgumentException.
+            condition = "#request != null && #request.hasAnyFilter()")
     public List<ZipCode> advancedSearch(AdvancedSearchRequest request) {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
@@ -626,7 +725,10 @@ public class ZipCodeService {
      * This keeps broad advanced searches from allocating all matching ZipCode
      * objects when clients only need one page.
      */
-    @Cacheable(value = "advancedSearchPaged", key = "#request == null ? 'null_' + #page + '_' + #size : #request.normalizedFilterCacheKey() + '_' + #page + '_' + #size")
+    @Cacheable(
+            value = "advancedSearchPaged",
+            key = "#request.normalizedFilterCacheKey() + '_' + #page + '_' + #size",
+            condition = "#request != null && #request.hasAnyFilter() && #page >= 0 && #size > 0")
     public PagedResponse<ZipCode> advancedSearch(AdvancedSearchRequest request, int page, int size) {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
@@ -693,6 +795,13 @@ public class ZipCodeService {
         return candidates;
     }
 
+    /**
+     * Fix #25: tras precomputar normalizedName/Type/Zone al cargar, los
+     * fallbacks {@code getX() != null ? ... : Util.normalizeString(...)} eran
+     * código muerto. Simplificamos al acceso directo: si en el futuro alguien
+     * mutiera Settlements en runtime, prefiero un NPE visible que un fallback
+     * silencioso que oculte el bug.
+     */
     private boolean matchesAdvancedCriteria(ZipCode zipCode, AdvancedSearchCriteria criteria) {
         if (isFilterPresent(criteria.normalizedEntity()) &&
                 !zipCode.getNormalizedFederalEntity().contains(criteria.normalizedEntity())) {
@@ -715,31 +824,17 @@ public class ZipCodeService {
     }
 
     private boolean matchesSettlementCriteria(Settlements settlement, AdvancedSearchCriteria criteria) {
-        if (isFilterPresent(criteria.normalizedSettlement())) {
-            String settlementName = settlement.getNormalizedName() != null
-                    ? settlement.getNormalizedName()
-                    : Util.normalizeString(settlement.getName());
-            if (!settlementName.contains(criteria.normalizedSettlement())) {
-                return false;
-            }
+        if (isFilterPresent(criteria.normalizedSettlement()) &&
+                !settlement.normalizedName().contains(criteria.normalizedSettlement())) {
+            return false;
         }
-
-        if (isFilterPresent(criteria.normalizedSettlementType())) {
-            String type = settlement.getNormalizedSettlementType() != null
-                    ? settlement.getNormalizedSettlementType()
-                    : Util.normalizeString(settlement.getSettlementType());
-            if (!type.contains(criteria.normalizedSettlementType())) {
-                return false;
-            }
+        if (isFilterPresent(criteria.normalizedSettlementType()) &&
+                !settlement.normalizedSettlementType().contains(criteria.normalizedSettlementType())) {
+            return false;
         }
-
         if (isFilterPresent(criteria.normalizedZoneType())) {
-            String zone = settlement.getNormalizedZoneType() != null
-                    ? settlement.getNormalizedZoneType()
-                    : Util.normalizeString(settlement.getZoneType());
-            return zone.contains(criteria.normalizedZoneType());
+            return settlement.normalizedZoneType().contains(criteria.normalizedZoneType());
         }
-
         return true;
     }
 
@@ -754,12 +849,6 @@ public class ZipCodeService {
     /**
      * Creates a paginated response from a list of results.
      * Uses long arithmetic to prevent overflow when page * size exceeds Integer.MAX_VALUE.
-     *
-     * @param allResults All results (already loaded in memory)
-     * @param page Page number (0-based)
-     * @param size Page size
-     * @param <T> Result type
-     * @return PaginatedResponse with the sliced results (empty if page exceeds bounds)
      */
     public static <T> PagedResponse<T> createPagedResponse(List<T> allResults, int page, int size) {
         validatePagination(page, size);
@@ -778,9 +867,38 @@ public class ZipCodeService {
     }
 
     /**
+     * Streaming pagination que ordena el conjunto candidato y materializa
+     * únicamente la página solicitada. Fix #8.
+     */
+    private static <T> PagedResponse<T> paginateSorted(
+            Set<T> candidates,
+            Comparator<T> comparator,
+            int page,
+            int size) {
+        validatePagination(page, size);
+
+        int totalElements = candidates.size();
+        int totalPages = calculateTotalPages(totalElements, size);
+        long offset = (long) page * size;
+
+        if (offset >= totalElements) {
+            return buildPagedResponse(List.of(), page, size, totalElements, totalPages);
+        }
+
+        int start = (int) offset;
+        int limit = Math.min(size, totalElements - start);
+        List<T> pageContent = candidates.stream()
+                .sorted(comparator)
+                .skip(start)
+                .limit(limit)
+                .toList();
+
+        return buildPagedResponse(pageContent, page, size, totalElements, totalPages);
+    }
+
+    /**
      * Creates a paginated response from a collection without materializing the full
      * filtered result set. The collection iteration order is preserved.
-     * This avoids allocating a List of ALL matches when only a small page is needed.
      */
     private static <T> PagedResponse<T> createPagedResponse(
             Collection<T> candidates,
@@ -851,14 +969,6 @@ public class ZipCodeService {
         return Util.normalizeSearchTerm(searchTerm);
     }
 
-    /**
-     * Resolves the smallest candidate set using available inverted indices.
-     *
-     * If an indexed filter is present but has no matches, it returns an empty
-     * candidate set immediately because advanced-search filters are combined with
-     * AND semantics. This avoids a full catalog scan for impossible entity or
-     * municipality criteria.
-     */
     private Collection<ZipCode> resolveSearchCandidates(String normalizedEntity, String normalizedMunicipality) {
         Set<ZipCode> entityCandidates = findCandidatesInIndex(zipCodesByNormalizedEntity, normalizedEntity);
         if (isFilterPresent(normalizedEntity) && entityCandidates.isEmpty()) {
@@ -890,9 +1000,12 @@ public class ZipCodeService {
     }
 
     /**
-     * Finds matching zip codes through a normalized inverted index and returns
-     * them in deterministic zip-code order. This limits entity/municipality
-     * searches to the small index key set instead of scanning the full catalog.
+     * Devuelve todos los ZipCodes coincidentes (en orden ascendente por código
+     * postal) recorriendo el índice invertido. {@code distinct()} es defensivo:
+     * cada ZipCode aparece sólo bajo una clave por dimensión (porque cada CP
+     * tiene una sola entidad/municipio), así que en práctica nunca hay
+     * duplicados. Conservamos {@code distinct()} para que el contrato sea
+     * robusto si en el futuro se admiten múltiples valores por ZipCode.
      */
     private List<ZipCode> findOrderedCandidatesInIndex(Map<String, Set<ZipCode>> index, String normalizedSearchTerm) {
         return index.entrySet().stream()

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,9 +10,10 @@ spring:
       on-profile: prod
   lifecycle:
     timeout-per-shutdown-phase: 30s
-  cache:
-    caffeine:
-      spec: maximumSize=10000,expireAfterAccess=1h,recordStats
+  # NOTA: la configuración real de cada cache se hace de forma programática en
+  # CacheConfiguration#cacheManager (Caffeine.newBuilder per región). El
+  # antiguo `spring.cache.caffeine.spec` global se ignora cuando hay registros
+  # personalizados y solo confunde.
 
 # Rate limiting estricto en producción
 ratelimit:
@@ -50,6 +51,11 @@ logging:
     max-history: 30
 
 server:
+  # Confiar en X-Forwarded-* sólo cuando Spring Boot las procesa vía ForwardedHeaderFilter.
+  # Esto requiere que el proxy/CDN del frente añada los headers y descarte cualquier valor
+  # entrante (sino, sigue siendo spoofable a nivel de proxy). El RateLimitInterceptor usará
+  # request.getRemoteAddr() que ya quedará resuelta a la IP real del cliente.
+  forward-headers-strategy: framework
   # Servidor con errores ocultos
   error:
     include-message: never  # NUNCA incluir mensajes de error internos

--- a/src/main/resources/application-qa.yml
+++ b/src/main/resources/application-qa.yml
@@ -8,6 +8,12 @@ spring:
   config:
     activate:
       on-profile: qa
+  # Caché con TTL más corto para pruebas (consolidado en un único bloque spring:
+  # para evitar duplicación de claves YAML, que SnakeYAML resuelve sobrescribiendo
+  # el primer bloque silenciosamente).
+  cache:
+    caffeine:
+      spec: maximumSize=5000,expireAfterAccess=10m
 
 # Rate limiting moderado para pruebas realistas
 ratelimit:
@@ -44,9 +50,3 @@ server:
     include-stacktrace: on-param  # Solo con ?trace=true
     include-exception: false
     include-binding-errors: always
-
-# Caché con TTL más corto para pruebas
-spring:
-  cache:
-    caffeine:
-      spec: maximumSize=5000,expireAfterAccess=10m

--- a/src/main/resources/application-railway.yml
+++ b/src/main/resources/application-railway.yml
@@ -12,6 +12,10 @@ spring:
 # Puerto dinámico (Railway asigna via $PORT)
 server:
   port: ${PORT:8080}
+  # Railway termina TLS en su edge y propaga X-Forwarded-*. Activar el filtro framework
+  # para que request.getRemoteAddr() devuelva la IP real del cliente y el rate limit
+  # por IP no sea trivialmente evadible mediante spoofing del header.
+  forward-headers-strategy: framework
   error:
     include-message: never
     include-stacktrace: never

--- a/src/test/java/com/coderalexis/CodigoPostalApi/config/RateLimitInterceptorTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/config/RateLimitInterceptorTest.java
@@ -2,13 +2,21 @@ package com.coderalexis.CodigoPostalApi.config;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RateLimitInterceptorTest {
 
-    private final RateLimitInterceptor interceptor = new RateLimitInterceptor(new RateLimitProperties());
+    private final RateLimitInterceptor interceptor =
+            new RateLimitInterceptor(new RateLimitProperties());
 
     @Test
     @DisplayName("Debe validar rangos CIDR IPv4 correctamente")
@@ -32,5 +40,100 @@ class RateLimitInterceptorTest {
         assertFalse(interceptor.ipMatchesCIDR("192.168.1.25", "192.168.1.0/33"));
         assertFalse(interceptor.ipMatchesCIDR("192.168.1.25", "192.168.1.0"));
         assertFalse(interceptor.ipMatchesCIDR("192.168.1.25", "not-an-ip/24"));
+    }
+
+    // ============================================================
+    // Tests añadidos en #22: cobertura del flujo preHandle completo
+    // ============================================================
+
+    @Test
+    @DisplayName("preHandle con rate limit deshabilitado deja pasar siempre")
+    void shouldPassThroughWhenDisabled() throws Exception {
+        RateLimitProperties props = new RateLimitProperties();
+        props.setEnabled(false);
+        RateLimitInterceptor disabled = new RateLimitInterceptor(props);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/zip-codes/01000");
+        request.setRemoteAddr("203.0.113.5");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertTrue(disabled.preHandle(request, response, new Object()));
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+    }
+
+    @Test
+    @DisplayName("preHandle con IP en whitelist deja pasar sin consumir bucket")
+    void shouldBypassRateLimitForWhitelistedIp() throws Exception {
+        RateLimitProperties props = new RateLimitProperties();
+        props.setEnabled(true);
+        props.setRequestsPerMinute(1);
+        props.setBurstCapacity(1);
+        props.setWhitelist(List.of("203.0.113.5"));
+        RateLimitInterceptor limited = new RateLimitInterceptor(props);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/zip-codes/01000");
+        request.setRemoteAddr("203.0.113.5");
+
+        // Una IP en whitelist debe pasar muchas veces aunque el bucket sea de 1
+        for (int i = 0; i < 5; i++) {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            assertTrue(limited.preHandle(request, response, new Object()),
+                    "La IP whitelisted no debe ser limitada (iteración " + i + ")");
+            assertEquals(HttpStatus.OK.value(), response.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("preHandle bloquea cuando se excede la capacidad del bucket")
+    void shouldBlockWhenBucketExhausted() throws Exception {
+        RateLimitProperties props = new RateLimitProperties();
+        props.setEnabled(true);
+        props.setRequestsPerMinute(1);
+        props.setBurstCapacity(2);
+        RateLimitInterceptor limited = new RateLimitInterceptor(props);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/zip-codes/01000");
+        request.setRemoteAddr("198.51.100.1");
+
+        // Las dos primeras peticiones consumen el burst y pasan.
+        for (int i = 0; i < 2; i++) {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            assertTrue(limited.preHandle(request, response, new Object()),
+                    "Las primeras peticiones dentro del burst deben pasar");
+            assertNotNull(response.getHeader("X-RateLimit-Limit"));
+            assertNotNull(response.getHeader("X-RateLimit-Remaining"));
+        }
+
+        // La tercera supera el burst → 429.
+        MockHttpServletResponse blocked = new MockHttpServletResponse();
+        assertFalse(limited.preHandle(request, blocked, new Object()));
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), blocked.getStatus());
+        assertEquals("0", blocked.getHeader("X-RateLimit-Remaining"));
+        assertNotNull(blocked.getHeader("X-RateLimit-Retry-After-Seconds"));
+        assertTrue(blocked.getContentAsString().contains("Limite de peticiones excedido"),
+                "El body debe usar el formato consistente con ErrorResponse");
+    }
+
+    @Test
+    @DisplayName("preHandle aísla buckets entre IPs cuando ip-based=true")
+    void shouldIsolateBucketsBetweenClients() throws Exception {
+        RateLimitProperties props = new RateLimitProperties();
+        props.setEnabled(true);
+        props.setIpBased(true);
+        props.setRequestsPerMinute(1);
+        props.setBurstCapacity(1);
+        RateLimitInterceptor limited = new RateLimitInterceptor(props);
+
+        MockHttpServletRequest clientA = new MockHttpServletRequest("GET", "/zip-codes/01000");
+        clientA.setRemoteAddr("198.51.100.10");
+        MockHttpServletRequest clientB = new MockHttpServletRequest("GET", "/zip-codes/01000");
+        clientB.setRemoteAddr("198.51.100.11");
+
+        // Cliente A agota su bucket.
+        assertTrue(limited.preHandle(clientA, new MockHttpServletResponse(), new Object()));
+        assertFalse(limited.preHandle(clientA, new MockHttpServletResponse(), new Object()));
+
+        // Cliente B sigue teniendo su propio bucket.
+        assertTrue(limited.preHandle(clientB, new MockHttpServletResponse(), new Object()));
     }
 }

--- a/src/test/java/com/coderalexis/CodigoPostalApi/controller/ControllerTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/controller/ControllerTest.java
@@ -238,4 +238,159 @@ class ControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.first").value(false));
     }
+
+    // ============================================================
+    // Tests añadidos en #22: cobertura de los endpoints restantes
+    // ============================================================
+
+    @Test
+    @DisplayName("GET /zip-codes/search - Debe devolver coincidencias de prefijo")
+    void shouldSearchByPartialCode() throws Exception {
+        mockMvc.perform(get("/zip-codes/search")
+                .param("code", "010")
+                .param("limit", "5")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$", hasSize(lessThanOrEqualTo(5))));
+    }
+
+    @Test
+    @DisplayName("GET /zip-codes/search?simplified=true - Debe responder formato compacto")
+    void shouldSearchByPartialCodeSimplified() throws Exception {
+        mockMvc.perform(get("/zip-codes/search")
+                .param("code", "010")
+                .param("limit", "3")
+                .param("simplified", "true")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].zip_code").exists())
+                // En la respuesta simplified no debe aparecer la lista de asentamientos
+                .andExpect(jsonPath("$[0].settlements").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET /zip-codes/search - Debe rechazar prefijo no numérico")
+    void shouldRejectNonNumericPartialCode() throws Exception {
+        mockMvc.perform(get("/zip-codes/search")
+                .param("code", "01a")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET /zip-codes/search - Debe respetar el límite máximo (50)")
+    void shouldRejectLimitGreaterThanFifty() throws Exception {
+        mockMvc.perform(get("/zip-codes/search")
+                .param("code", "01")
+                .param("limit", "999")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET /zip-codes/federal-entities - Debe listar entidades")
+    void shouldListFederalEntities() throws Exception {
+        mockMvc.perform(get("/zip-codes/federal-entities")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$", hasSize(greaterThan(0))))
+                .andExpect(jsonPath("$[0].name").exists())
+                .andExpect(jsonPath("$[0].zip_codes_count").exists());
+    }
+
+    @Test
+    @DisplayName("GET /zip-codes/federal-entities/{x}/municipalities - Debe devolver municipios")
+    void shouldListMunicipalitiesByFederalEntity() throws Exception {
+        mockMvc.perform(get("/zip-codes/federal-entities/Jalisco/municipalities")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$", hasSize(greaterThan(0))));
+    }
+
+    @Test
+    @DisplayName("GET /zip-codes/federal-entities/{x}/municipalities - 404 si no existe")
+    void shouldReturn404ForUnknownFederalEntityMunicipalities() throws Exception {
+        mockMvc.perform(get("/zip-codes/federal-entities/EntidadInexistente12345XYZ/municipalities")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /zip-codes/{cp}/settlements - Debe devolver colonias")
+    void shouldListSettlementsByZipCode() throws Exception {
+        mockMvc.perform(get("/zip-codes/01000/settlements")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$", hasSize(greaterThan(0))))
+                .andExpect(jsonPath("$[0].name").exists());
+    }
+
+    @Test
+    @DisplayName("GET /zip-codes/{cp}/settlements - 404 si código postal no existe")
+    void shouldReturn404ForUnknownZipCodeSettlements() throws Exception {
+        mockMvc.perform(get("/zip-codes/99999/settlements")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /zip-codes/advanced - Debe combinar filtros con paginación")
+    void shouldRunAdvancedSearch() throws Exception {
+        mockMvc.perform(get("/zip-codes/advanced")
+                .param("federal_entity", "Jalisco")
+                .param("municipality", "Guadalajara")
+                .param("page", "0")
+                .param("size", "5")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content", hasSize(lessThanOrEqualTo(5))))
+                .andExpect(jsonPath("$.pageNumber").value(0));
+    }
+
+    @Test
+    @DisplayName("GET /zip-codes/advanced?simplified=true - Debe responder formato compacto")
+    void shouldRunAdvancedSearchSimplified() throws Exception {
+        mockMvc.perform(get("/zip-codes/advanced")
+                .param("federal_entity", "Jalisco")
+                .param("municipality", "Guadalajara")
+                .param("simplified", "true")
+                .param("size", "3")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].settlements_count").exists());
+    }
+
+    @Test
+    @DisplayName("GET /zip-codes/advanced - 400 si no hay ningún filtro")
+    void shouldRejectAdvancedSearchWithNoFilters() throws Exception {
+        mockMvc.perform(get("/zip-codes/advanced")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Las respuestas REST deben incluir el header Cache-Control")
+    void shouldAddCacheControlToSuccessfulResponses() throws Exception {
+        mockMvc.perform(get("/zip-codes/01000")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Cache-Control"))
+                .andExpect(header().string("Cache-Control", org.hamcrest.Matchers.containsString("max-age=")));
+    }
+
+    @Test
+    @DisplayName("Las respuestas de error NO deben incluir Cache-Control")
+    void shouldNotAddCacheControlToErrors() throws Exception {
+        mockMvc.perform(get("/zip-codes/99999")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(header().doesNotExist("Cache-Control"));
+    }
 }

--- a/src/test/java/com/coderalexis/CodigoPostalApi/health/ZipCodeHealthIndicatorTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/health/ZipCodeHealthIndicatorTest.java
@@ -1,0 +1,56 @@
+package com.coderalexis.CodigoPostalApi.health;
+
+import com.coderalexis.CodigoPostalApi.service.ZipCodeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests añadidos en #22 para cubrir las tres ramas del health indicator que
+ * antes se ejercitaban sólo indirectamente.
+ */
+class ZipCodeHealthIndicatorTest {
+
+    @Test
+    @DisplayName("UP cuando los datos están cargados y hay códigos postales")
+    void shouldBeUpWhenDataLoaded() {
+        ZipCodeService service = mock(ZipCodeService.class);
+        when(service.isDataLoaded()).thenReturn(true);
+        when(service.getZipCodeCount()).thenReturn(145_000);
+
+        Health health = new ZipCodeHealthIndicator(service).health();
+
+        assertEquals(Status.UP, health.getStatus());
+        assertEquals(145_000, health.getDetails().get("zipCodeCount"));
+    }
+
+    @Test
+    @DisplayName("DOWN cuando los datos NO están cargados")
+    void shouldBeDownWhenDataNotLoaded() {
+        ZipCodeService service = mock(ZipCodeService.class);
+        when(service.isDataLoaded()).thenReturn(false);
+
+        Health health = new ZipCodeHealthIndicator(service).health();
+
+        assertEquals(Status.DOWN, health.getStatus());
+        assertEquals("Zip codes data not loaded", health.getDetails().get("reason"));
+    }
+
+    @Test
+    @DisplayName("DOWN cuando se cargaron pero quedaron cero códigos postales")
+    void shouldBeDownWhenZeroZipCodes() {
+        ZipCodeService service = mock(ZipCodeService.class);
+        when(service.isDataLoaded()).thenReturn(true);
+        when(service.getZipCodeCount()).thenReturn(0);
+
+        Health health = new ZipCodeHealthIndicator(service).health();
+
+        assertEquals(Status.DOWN, health.getStatus());
+        assertEquals("No zip codes available", health.getDetails().get("reason"));
+    }
+}

--- a/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
@@ -254,25 +254,19 @@ class ZipCodeServiceTest {
     @Test
     @DisplayName("Debe usar la misma llave de cache avanzada para distintas paginas y formatos")
     void shouldUseSameAdvancedSearchCacheKeyForPaginationAndFormatOptions() {
-        AdvancedSearchRequest firstPage = AdvancedSearchRequest.builder()
+        AdvancedSearchRequest mixedCase = AdvancedSearchRequest.builder()
                 .federalEntity(" Jalisco ")
                 .municipality("Guadalajara")
                 .zoneType("Urbano")
-                .page(0)
-                .size(20)
-                .simplified(false)
                 .build();
 
-        AdvancedSearchRequest secondPageSimplified = AdvancedSearchRequest.builder()
+        AdvancedSearchRequest lowercase = AdvancedSearchRequest.builder()
                 .federalEntity("jalisco")
                 .municipality("guadalajara")
                 .zoneType("urbano")
-                .page(3)
-                .size(5)
-                .simplified(true)
                 .build();
 
-        assertEquals(firstPage.normalizedFilterCacheKey(), secondPageSimplified.normalizedFilterCacheKey(),
+        assertEquals(mixedCase.normalizedFilterCacheKey(), lowercase.normalizedFilterCacheKey(),
             "La cache de busqueda avanzada debe depender solo de los filtros normalizados");
     }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,11 +6,20 @@ spring:
 
 zipcode:
   file:
-    path: CPdescarga.txt
+    # Antes era 'CPdescarga.txt' relativo y se cargaba via el fallback
+    # silencioso del classpath. Tras el fix #20 los paths explícitos deben
+    # existir; usamos el prefijo classpath: para ser claros sobre el origen.
+    path: classpath:CPdescarga.txt
 
 # Desactivar rate limiting en tests
 ratelimit:
   enabled: false
+
+# Desactivar warmup en tests: ya se ejercitan los caches en los propios tests
+# y precargar añade ~10 búsquedas paralelas al arranque que ralentizan la suite.
+cache:
+  warmup:
+    enabled: false
 
 # Logging reducido para tests
 logging:


### PR DESCRIPTION
## Summary

Aplica las 25 correcciones identificadas en el análisis del codebase. La rama está dividida en 4 commits temáticos para facilitar la revisión y `git bisect`.

| # | Categoría | Fix |
|---|-----------|-----|
| 1 | bug | `spring:` duplicado en `application-qa.yml` (SnakeYAML lo sobreescribía silenciosamente) |
| 2 | bug | `dataLoaded` se marcaba `true` antes de poblar `cachedStats`/`cachedFederalEntities` |
| 3 | security | `X-Forwarded-For` se confiaba a ciegas → bypass trivial del rate-limit por IP |
| 4 | code smell | `page`/`size`/`simplified` en el DTO eran código muerto que entraba en conflicto con los query params |
| 5 | perf | Cache de `partialSearch` con `#limit` en la key generaba ≤50 entradas por mismo prefijo |
| 6 | perf | `cache.warmup.enabled=true` en tests añadía 10 búsquedas paralelas al arranque |
| 7 | bug | JSON del 429 manual, fuera de formato y sin `path` |
| 8 | perf | Paginación de entidad/municipio materializaba ≥25k entradas para devolver una página de 20 |
| 9 | perf | `getMunicipalitiesByFederalEntity` recorría todos los ZipCodes en vez de un índice precomputado |
| 10 | perf | `buildPreComputedData` recorría `values()` 2 veces |
| 11 | dead code | `spring.cache.caffeine.spec` en `prod.yml` era ignorado por la config programática |
| 12 | dead code | `@JsonInclude(NON_NULL)` en `ZipCode` ya estaba global |
| 13 | observability | `recordStats()` activo sin exponer a Micrometer/Prometheus |
| 14 | verificación | `partialSearch` ya normalizaba via `normalizeCacheKey` (documentado) |
| 15 | code smell | Métricas duplicadas entre versión paginada / no paginada |
| 16 | refactor | OpenAPI inline en `Controller.java` (586 líneas) → extraído a `ZipCodeApi` |
| 17 | code smell | Métodos no paginados cachean listas multi-miles e infrautilizados |
| 18 | code smell | `Settlements` con `@Data` + `Serializable` mientras hermano `ZipCode` usaba `@EqualsAndHashCode(of)` |
| 19 | perf | `@Cacheable` evaluaba SpEL antes de validación → entradas con keys de basura |
| 20 | bug | `getInputStream` enmascaraba paths mal configurados con fallback silencioso |
| 21 | deps | `<lombok.version>` sobreescribía la versión del BOM de Spring Boot |
| 22 | quality | Falta de tests para `/search`, `/advanced`, `/federal-entities`, settlements, health, rate-limit flow |
| 23 | perf | Cache-Control sólo en estáticos; las respuestas REST no eran cacheables por CDN/cliente |
| 24 | clarity | `distinct()` defensivo sin documentación |
| 25 | dead code | Fallback de normalización en `matchesSettlementCriteria` muerto tras precomputado |

## Estructura de la rama

- **`db1072a` chore(config)** — YAML profiles + BOM Lombok (#1, #6, #11, #20-test, #21, #3-yaml)
- **`0d0f59b` refactor(api+service)** — Settlements record, ZipCodeApi interface, service rewrite, cache metrics (#2, #4, #5, #8, #9, #10, #12, #13, #14, #15, #16, #17, #18, #19, #20-service, #24, #25)
- **`f5ec806` feat(http)** — forward-headers trust + 429 estructurado + CacheControlInterceptor (#3-service, #7, #23)
- **`aba3650` test** — cobertura de endpoints + health indicator (#22)

## Métricas

- `Controller.java`: 586 → 110 líneas (la documentación OpenAPI vive ahora en `ZipCodeApi`)
- Tests: 33 → **66** (todos verde)
- `ZipCodeService.java`: +172 líneas netas (índice de municipios, streaming pagination, race fix, deprecation notes)

## Test plan

- [x] `mvn clean test` → 66/66 verde localmente
- [ ] CI ejecuta la suite completa
- [ ] Verificar en el proxy/CDN (Railway, Cloudflare) que se descartan `X-Forwarded-*` entrantes antes de añadir los del edge (requisito para que `forward-headers-strategy: framework` sea seguro)
- [ ] Confirmar en Prometheus que aparecen las nuevas métricas `cache_gets_total{cache="..."}`, `cache_evictions_total`, etc.
- [ ] Verificar headers `Cache-Control` con `curl -I` en cada endpoint
- [ ] Confirmar que el JSON 429 ahora coincide con el shape de `ErrorResponse`

## Notas para el reviewer

- **Backward compat**: el JSON serializado no cambia (Settlements record produce el mismo output que la clase Lombok). Los endpoints siguen idénticos.
- **`Settlements` ya no es `Serializable`** — si algún consumer externo serializaba binariamente, se rompe. No tenemos consumers de ese tipo.
- **`server.forward-headers-strategy: framework`** sólo es seguro si el edge proxy descarta los headers entrantes; revisar config de Railway/CDN.
- **Métodos `searchByFederalEntity(String)` / `searchByMunicipality(String)` / `advancedSearch(AdvancedSearchRequest)`** quedan `@Deprecated(forRemoval = false)` — no se borran porque los tests aún los exercen, pero el controller ya no los usa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)