### PR TITLE
refactor: fail-fast load, extract loader & pagination, immutable ZipCode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,43 +1,43 @@
 # CLAUDE.md - Project Guidelines
 
 ## Project Overview
-High-performance REST API for querying Mexican postal codes (ZIP codes). Built with **Spring Boot 4.0.2** and **Java 25**. Data is loaded from SEPOMEX's `CPdescarga.txt` file into in-memory data structures at startup.
+High-performance REST API for querying Mexican postal codes (ZIP codes). Built with **Spring Boot 4.0.6** and **Java 25**. Data is loaded from SEPOMEX's `CPdescarga.txt` file into in-memory data structures at startup.
 
 ## Build & Run
 ```bash
 mvn clean package              # Build JAR
 mvn spring-boot:run            # Run with dev profile
-mvn test                       # Run all 33 tests (14 unit + 18 integration + 1 context)
+mvn test                       # Run all 66 tests (service + controller + rate-limit + health + context)
 mvn spring-boot:run -Dspring-boot.run.profiles=prod  # Run with production profile
 ```
 
 ## Architecture
 
 ### Data Flow
-1. **Startup**: `CPdescarga.txt` is loaded in `@PostConstruct`, parsed line-by-line, and indexed into multiple concurrent data structures
-2. **Indexing**: Four index structures for different access patterns:
-   - `ConcurrentHashMap<String, ZipCode>` - O(1) direct lookup by zip code
-   - `ConcurrentSkipListMap<String, ZipCode>` - O(log n) prefix search (autocomplete)
+1. **Startup**: `CPdescarga.txt` is loaded in `@PostConstruct`, parsed line-by-line, and indexed into multiple in-memory data structures. The load is **fail-fast**: if the catalog is missing or ends up empty, startup is aborted (`IllegalStateException`) instead of leaving a running-but-broken service.
+2. **Indexing**: Four index structures for different access patterns. They are populated sequentially during the single-threaded `@PostConstruct` and treated as **read-only after load**, so plain (non-concurrent) collections are used to avoid synchronization overhead on the hot read path:
+   - `HashMap<String, ZipCode>` - O(1) direct lookup by zip code
+   - `TreeMap<String, ZipCode>` (`NavigableMap`) - O(log n) prefix search (autocomplete) via `subMap()`
    - `Map<String, Set<ZipCode>>` - Inverted index by normalized federal entity
    - `Map<String, Set<ZipCode>>` - Inverted index by normalized municipality
-3. **Pre-computation**: Statistics and federal entities list are computed once at startup (immutable after load)
-4. **Caching**: 7 Caffeine cache regions with different TTLs per data type
-5. **Serving**: REST endpoints in `Controller.java` with pagination, validation, and Swagger docs
+3. **Pre-computation**: Statistics, federal entities list, and the municipalities-by-entity index are computed once at startup (immutable after load)
+4. **Caching**: 5 Spring-managed Caffeine cache regions (`zipcodes`, `federalEntitySearchPaged`, `municipalitySearchPaged`, `municipalitiesByEntity`, `advancedSearchPaged`) plus a manually-managed `partialPrefixCache` (Caffeine) inside `ZipCodeService` to sidestep Spring's self-invocation pitfall
+5. **Serving**: REST endpoints in `Controller.java` (contract in `ZipCodeApi` interface) with pagination, validation, and Swagger docs
 
 ### Key Design Decisions
 - **No database**: All data in memory (~200MB RAM) for sub-millisecond lookups
 - **Pre-computed normalized fields**: `ZipCode` stores `normalizedFederalEntity` and `normalizedMunicipality` (computed at load time) to avoid NFD normalization in hot search paths
-- **`@EqualsAndHashCode(of = "zipCode")`**: ZipCode identity is based solely on the zip code string, not the mutable settlements list. This is critical for correctness in the inverted index Sets
+- **`@EqualsAndHashCode(of = "zipCode")`**: ZipCode identity is based solely on the zip code string, not the settlements list. This is critical for correctness in the inverted index Sets (each ZipCode's `settlements` list is replaced with an immutable `List.copyOf(...)` after load, and `Settlements` itself is an immutable record)
 - **Sequential streams for small indices**: Federal entity index has ~32 entries, municipality ~2500. `parallelStream()` overhead exceeds benefit at these sizes
-- **`ConcurrentSkipListMap.subMap()`**: Prefix search uses sorted map range query instead of full scan
+- **`TreeMap.subMap()`**: Prefix search uses sorted map range query instead of full scan
 - **Low-cardinality metrics**: Search metrics use type tags (direct/federal_entity/municipality/partial) instead of per-zipcode counters to avoid Prometheus series explosion
 - **Caffeine for rate limit buckets**: Auto-eviction after 5 min of inactivity prevents memory leaks vs unbounded ConcurrentHashMap
 
 ### Project Structure
 ```
 src/main/java/com/coderalexis/CodigoPostalApi/
-  config/         # CacheConfiguration, MetricsConfiguration, RateLimitInterceptor, SwaggerConfiguration, CacheWarmupRunner, WebMvcConfiguration, RateLimitProperties
-  controller/     # Controller.java - all REST endpoints under /zip-codes
+  config/         # CacheConfiguration, CacheControlInterceptor, MetricsConfiguration, RateLimitInterceptor, SwaggerConfiguration, CacheWarmupRunner, WebMvcConfiguration, RateLimitProperties
+  controller/     # ZipCodeApi (REST contract + OpenAPI/validation) + Controller.java (implementation), all under /zip-codes
   exceptions/     # GlobalExceptionHandler, ZipCodeNotFoundException, ErrorResponse
   health/         # ZipCodeHealthIndicator
   model/          # ZipCode, Settlements, ZipCodeSimplified, FederalEntity, PagedResponse, ZipCodeStats, AdvancedSearchRequest
@@ -61,8 +61,8 @@ src/main/java/com/coderalexis/CodigoPostalApi/
 - JSON: snake_case via `@JsonProperty` annotations
 
 ## Performance Notes
-- Direct zip code lookup: O(1) HashMap + Caffeine cache
-- Partial/prefix search: O(log n + k) via ConcurrentSkipListMap.subMap()
+- Direct zip code lookup: O(1) HashMap (no cache: Map access is already O(1))
+- Partial/prefix search: O(log n + k) via TreeMap (NavigableMap) `subMap()`, results cached per-prefix in `partialPrefixCache`
 - Federal entity/municipality search: O(m) where m = matching index entries (not full scan)
 - Advanced search: Uses inverted indices as starting point, reduces candidate set before filtering
 - Statistics & federal entities: Pre-computed at startup, O(1) retrieval

--- a/src/main/java/com/coderalexis/CodigoPostalApi/config/CacheConfiguration.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/config/CacheConfiguration.java
@@ -25,13 +25,9 @@ public class CacheConfiguration {
     public CacheManager cacheManager() {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager(
                 "zipcodes",
-                "federalEntitySearch",
                 "federalEntitySearchPaged",
-                "municipalitySearch",
                 "municipalitySearchPaged",
-                "federalEntities",
                 "municipalitiesByEntity",
-                "advancedSearch",
                 "advancedSearchPaged"
         );
 
@@ -44,23 +40,8 @@ public class CacheConfiguration {
                         .recordStats()
                         .build());
 
-        // Federal entity search: results can be large (full ZipCode objects with settlements).
-        registerCache(cacheManager, "federalEntitySearch",
-                Caffeine.newBuilder()
-                        .maximumSize(50)
-                        .expireAfterWrite(5, TimeUnit.MINUTES)
-                        .recordStats()
-                        .build());
-
-        // Paginated variant: more specific keys, separate cache entry.
+        // Federal entity search (paginated): results can be large (full ZipCode objects with settlements).
         registerCache(cacheManager, "federalEntitySearchPaged",
-                Caffeine.newBuilder()
-                        .maximumSize(100)
-                        .expireAfterWrite(5, TimeUnit.MINUTES)
-                        .recordStats()
-                        .build());
-
-        registerCache(cacheManager, "municipalitySearch",
                 Caffeine.newBuilder()
                         .maximumSize(100)
                         .expireAfterWrite(5, TimeUnit.MINUTES)
@@ -77,25 +58,13 @@ public class CacheConfiguration {
         // NOTA: la cache de búsqueda parcial (autocompletado) se gestiona directamente
         // con Caffeine en ZipCodeService para evitar la trampa de self-invocation de
         // Spring Cache.
-
-        registerCache(cacheManager, "federalEntities",
-                Caffeine.newBuilder()
-                        .maximumSize(1)
-                        .expireAfterWrite(1, TimeUnit.HOURS)
-                        .recordStats()
-                        .build());
+        // NOTA: getAllFederalEntities() ya NO se cachea (devuelve un campo inmutable
+        // en memoria), por eso no se registra la región "federalEntities".
 
         registerCache(cacheManager, "municipalitiesByEntity",
                 Caffeine.newBuilder()
                         .maximumSize(50)
                         .expireAfterWrite(30, TimeUnit.MINUTES)
-                        .recordStats()
-                        .build());
-
-        registerCache(cacheManager, "advancedSearch",
-                Caffeine.newBuilder()
-                        .maximumSize(25)
-                        .expireAfterWrite(5, TimeUnit.MINUTES)
                         .recordStats()
                         .build());
 

--- a/src/main/java/com/coderalexis/CodigoPostalApi/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/exceptions/GlobalExceptionHandler.java
@@ -11,7 +11,6 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.stream.Collectors;
 
@@ -110,20 +109,5 @@ public class GlobalExceptionHandler {
         );
         log.warn("IllegalArgumentException: {}", ex.getMessage());
         return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
-    }
-
-    @ExceptionHandler(IOException.class)
-    public ResponseEntity<ErrorResponse> handleIOException(
-            IOException ex,
-            WebRequest request
-    ) {
-        ErrorResponse error = new ErrorResponse(
-                HttpStatus.SERVICE_UNAVAILABLE.value(),
-                "Error al acceder a los datos",
-                "El servicio no puede acceder a los datos en este momento",
-                LocalDateTime.now()
-        );
-        log.error("IOException: ", ex);
-        return new ResponseEntity<>(error, HttpStatus.SERVICE_UNAVAILABLE);
     }
 }

--- a/src/main/java/com/coderalexis/CodigoPostalApi/model/ZipCode.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/model/ZipCode.java
@@ -2,40 +2,45 @@ package com.coderalexis.CodigoPostalApi.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
 import java.util.List;
 
 /**
- * NOTA sobre @JsonInclude: la inclusión NON_NULL ya está configurada
+ * Código postal con sus asentamientos. Es <strong>inmutable</strong> (#11): se
+ * construye una sola vez durante la carga del catálogo (vía {@code @Builder}) y
+ * sus campos no cambian después. Esto elimina cualquier posibilidad de mutación
+ * accidental del estado interno una vez publicado en los índices.
+ *
+ * <p>NOTA sobre @JsonInclude: la inclusión NON_NULL ya está configurada
  * globalmente en application.yml (spring.jackson.default-property-inclusion),
- * así que no hace falta repetirla aquí.
+ * así que no hace falta repetirla aquí.</p>
  */
 @Getter
-@Setter
 @ToString
-@NoArgsConstructor
+@Builder
+@AllArgsConstructor
 @EqualsAndHashCode(of = "zipCode")
 public class ZipCode {
     @JsonProperty("zip_code")
-    private String zipCode;
+    private final String zipCode;
 
-    private String locality;
+    private final String locality;
 
     @JsonProperty("federal_entity")
-    private String federalEntity;
+    private final String federalEntity;
 
-    private String municipality;
+    private final String municipality;
 
-    private List<Settlements> settlements;
-
-    @JsonIgnore
-    private String normalizedFederalEntity;
+    private final List<Settlements> settlements;
 
     @JsonIgnore
-    private String normalizedMunicipality;
+    private final String normalizedFederalEntity;
+
+    @JsonIgnore
+    private final String normalizedMunicipality;
 }

--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/SepomexZipCodeLoader.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/SepomexZipCodeLoader.java
@@ -1,0 +1,339 @@
+package com.coderalexis.CodigoPostalApi.service;
+
+import com.coderalexis.CodigoPostalApi.model.Settlements;
+import com.coderalexis.CodigoPostalApi.model.ZipCode;
+import com.coderalexis.CodigoPostalApi.util.Util;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+
+/**
+ * Carga y parseo del catálogo SEPOMEX ({@code CPdescarga.txt}). Extraído de
+ * {@code ZipCodeService} (#10) para que esa clase quede enfocada en las consultas;
+ * aquí vive todo lo relativo a I/O, detección de encoding y construcción de los
+ * índices a partir del archivo.
+ *
+ * <p>El resultado ({@link ZipCodeData}) contiene {@link ZipCode} ya inmutables:
+ * primero se acumulan los asentamientos de cada código postal en una estructura
+ * temporal y luego se construye el objeto definitivo, evitando exponer estado
+ * mutable.</p>
+ */
+@Slf4j
+@Component
+public class SepomexZipCodeLoader {
+
+    // Pre-compiled Pattern for splitting lines (avoids recompiling on every split call)
+    private static final Pattern PIPE_PATTERN = Pattern.compile("\\|");
+
+    // Column indices based on CPdescarga.txt structure
+    private static final int COL_ZIP_CODE = 0;
+    private static final int COL_SETTLEMENT_NAME = 1;
+    private static final int COL_SETTLEMENT_TYPE = 2;
+    private static final int COL_MUNICIPALITY = 3;
+    private static final int COL_FEDERAL_ENTITY = 4;
+    private static final int COL_LOCALITY = 5;
+    private static final int COL_ZONE_TYPE_INDEX = 13;
+    private static final int MIN_COLUMNS = 6;
+    private static final int MAX_ERRORS_THRESHOLD = 100;
+    private static final int CHARSET_SAMPLE_SIZE = 4096;
+
+    private static final Pattern ZIP_CODE_PATTERN = Pattern.compile("^\\d{5}$");
+
+    private static final String RESOURCE_FILE = "CPdescarga.txt";
+
+    @Value("${zipcode.file.path}")
+    private String filePath;
+
+    private int errorCount = 0;
+
+    /**
+     * Carga el catálogo y devuelve las cuatro estructuras de índice ya construidas.
+     *
+     * @return los índices, o {@code null} si no se pudo localizar ningún archivo.
+     * @throws IOException si ocurre un error de lectura sobre un origen existente.
+     */
+    public ZipCodeData load() throws IOException {
+        try (InputStream stream = getInputStream()) {
+            if (stream == null) {
+                return null;
+            }
+            return parse(stream);
+        }
+    }
+
+    private ZipCodeData parse(InputStream stream) throws IOException {
+        long startTime = System.currentTimeMillis();
+        errorCount = 0;
+
+        BufferedInputStream bufferedStream = new BufferedInputStream(stream);
+        Charset charset = detectCharset(bufferedStream);
+        log.info("Encoding detectado: {}", charset.name());
+
+        // Estructura temporal mutable: acumula los asentamientos por código postal
+        // antes de materializar el ZipCode inmutable.
+        Map<String, Accumulator> accumulators = new HashMap<>();
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(bufferedStream, charset))) {
+
+            // Skip first two lines (metadata and header)
+            reader.readLine();
+            reader.readLine();
+
+            long linesProcessed = reader.lines()
+                    .filter(line -> processLine(line, accumulators))
+                    .count();
+
+            ZipCodeData data = buildIndices(accumulators);
+
+            long duration = System.currentTimeMillis() - startTime;
+            log.info("Datos cargados exitosamente en {}ms", duration);
+            log.info("  - Codigos postales unicos: {}", data.byCode().size());
+            log.info("  - Entidades federativas: {}", data.byNormalizedEntity().size());
+            log.info("  - Municipios: {}", data.byNormalizedMunicipality().size());
+            log.info("  - Lineas procesadas: {}", linesProcessed);
+            if (errorCount > 0) {
+                log.warn("  - Lineas con errores: {}", errorCount);
+            }
+
+            return data;
+        }
+    }
+
+    private ZipCodeData buildIndices(Map<String, Accumulator> accumulators) {
+        Map<String, ZipCode> byCode = new HashMap<>(accumulators.size() * 2);
+        NavigableMap<String, ZipCode> sorted = new TreeMap<>();
+        Map<String, Set<ZipCode>> byNormalizedEntity = new HashMap<>();
+        Map<String, Set<ZipCode>> byNormalizedMunicipality = new HashMap<>();
+
+        for (Accumulator acc : accumulators.values()) {
+            ZipCode zipCode = acc.toImmutable();
+
+            byCode.put(zipCode.getZipCode(), zipCode);
+            sorted.put(zipCode.getZipCode(), zipCode);
+            byNormalizedEntity
+                    .computeIfAbsent(zipCode.getNormalizedFederalEntity(), k -> new HashSet<>())
+                    .add(zipCode);
+            byNormalizedMunicipality
+                    .computeIfAbsent(zipCode.getNormalizedMunicipality(), k -> new HashSet<>())
+                    .add(zipCode);
+        }
+
+        return new ZipCodeData(byCode, sorted, byNormalizedEntity, byNormalizedMunicipality);
+    }
+
+    /**
+     * Resuelve el InputStream del catálogo SEPOMEX.
+     *
+     * <p>Fix #20: si el usuario configura un path explícito (vía
+     * {@code zipcode.file.path}) y éste no existe, fallamos rápido en vez de
+     * caer silenciosamente al recurso interno, que enmascaraba problemas de
+     * despliegue (config incorrecta sin error visible).</p>
+     */
+    private InputStream getInputStream() throws IOException {
+        boolean userConfiguredPath = filePath != null && !filePath.isBlank();
+
+        if (userConfiguredPath && filePath.startsWith("classpath:")) {
+            String resourcePath = filePath.substring("classpath:".length());
+            ClassPathResource resource = new ClassPathResource(resourcePath);
+            if (resource.exists()) {
+                log.info("Cargando codigos postales desde classpath: {}", resourcePath);
+                return resource.getInputStream();
+            }
+            throw new IOException(
+                "Recurso configurado en 'zipcode.file.path' no encontrado en classpath: " + resourcePath);
+        }
+
+        if (userConfiguredPath) {
+            Path path = Paths.get(filePath);
+            if (Files.exists(path)) {
+                log.info("Cargando codigos postales desde {}", filePath);
+                return Files.newInputStream(path);
+            }
+            throw new IOException(
+                "Archivo configurado en 'zipcode.file.path' no encontrado: " + filePath);
+        }
+
+        ClassPathResource resource = new ClassPathResource(RESOURCE_FILE);
+        if (resource.exists()) {
+            log.info("Cargando codigos postales desde recurso interno {}", RESOURCE_FILE);
+            return resource.getInputStream();
+        }
+
+        return null;
+    }
+
+    private Charset detectCharset(BufferedInputStream stream) throws IOException {
+        stream.mark(CHARSET_SAMPLE_SIZE);
+        byte[] sample = new byte[CHARSET_SAMPLE_SIZE];
+        int bytesRead = stream.read(sample);
+        stream.reset();
+
+        if (bytesRead <= 0) {
+            return StandardCharsets.UTF_8;
+        }
+
+        boolean hasHighBytes = false;
+        boolean hasUtf8Sequences = false;
+
+        for (int i = 0; i < bytesRead; i++) {
+            int b = sample[i] & 0xFF;
+            if (b >= 0x80) {
+                hasHighBytes = true;
+                if ((b & 0xE0) == 0xC0 || (b & 0xF0) == 0xE0) {
+                    if (i + 1 < bytesRead && (sample[i + 1] & 0xC0) == 0x80) {
+                        hasUtf8Sequences = true;
+                    }
+                }
+            }
+        }
+
+        if (hasHighBytes && !hasUtf8Sequences) {
+            log.debug("Detectado encoding ISO-8859-1 (bytes altos sin secuencias UTF-8)");
+            return StandardCharsets.ISO_8859_1;
+        }
+
+        if (hasUtf8Sequences) {
+            log.debug("Detectado encoding UTF-8 (secuencias UTF-8 validas encontradas)");
+            return StandardCharsets.UTF_8;
+        }
+
+        log.debug("Usando encoding por defecto ISO-8859-1 para archivo SEPOMEX");
+        return StandardCharsets.ISO_8859_1;
+    }
+
+    private boolean processLine(String line, Map<String, Accumulator> accumulators) {
+        try {
+            String[] words = PIPE_PATTERN.split(line);
+
+            if (words.length < MIN_COLUMNS) {
+                handleError("Linea con formato incorrecto (columnas insuficientes): {}",
+                    line.substring(0, Math.min(100, line.length())));
+                return false;
+            }
+
+            String zipCodeKey = words[COL_ZIP_CODE].trim();
+
+            if (!isValidZipCode(zipCodeKey)) {
+                handleError("Codigo postal invalido '{}' en linea: {}",
+                    zipCodeKey, line.substring(0, Math.min(100, line.length())));
+                return false;
+            }
+
+            if (words[COL_FEDERAL_ENTITY].trim().isEmpty() ||
+                words[COL_MUNICIPALITY].trim().isEmpty()) {
+                handleError("Campos requeridos vacios en codigo postal: {}", zipCodeKey);
+                return false;
+            }
+
+            String federalEntity = words[COL_FEDERAL_ENTITY].trim();
+            String municipality = words[COL_MUNICIPALITY].trim();
+
+            // El primer registro de un código postal fija entidad/municipio/localidad;
+            // los siguientes sólo añaden asentamientos.
+            Accumulator acc = accumulators.computeIfAbsent(zipCodeKey, k -> new Accumulator(
+                    k,
+                    words[COL_LOCALITY].trim(),
+                    federalEntity,
+                    municipality,
+                    Util.normalizeString(federalEntity),
+                    Util.normalizeString(municipality)));
+
+            String settlementName = words[COL_SETTLEMENT_NAME].trim();
+            String settlementTypeVal = words[COL_SETTLEMENT_TYPE].trim();
+            String zoneTypeVal = words.length > COL_ZONE_TYPE_INDEX ?
+                words[COL_ZONE_TYPE_INDEX].trim() : "";
+
+            // Fix #18: Settlements es un record inmutable con los campos normalizados precomputados.
+            acc.settlements.add(new Settlements(
+                    settlementName,
+                    zoneTypeVal,
+                    settlementTypeVal,
+                    Util.normalizeString(settlementName),
+                    Util.normalizeString(settlementTypeVal),
+                    Util.normalizeString(zoneTypeVal)));
+
+            return true;
+
+        } catch (Exception e) {
+            handleError("Error procesando la linea: {}",
+                line.substring(0, Math.min(100, line.length())));
+            log.debug("Detalle del error:", e);
+            return false;
+        }
+    }
+
+    private void handleError(String message, Object... args) {
+        errorCount++;
+        if (errorCount <= MAX_ERRORS_THRESHOLD) {
+            log.warn(message, args);
+        } else if (errorCount == MAX_ERRORS_THRESHOLD + 1) {
+            log.warn("Se alcanzo el limite de {} errores. Los siguientes errores no se mostraran.", MAX_ERRORS_THRESHOLD);
+        }
+    }
+
+    private boolean isValidZipCode(String zipCode) {
+        return zipCode != null && ZIP_CODE_PATTERN.matcher(zipCode).matches();
+    }
+
+    /**
+     * Estado temporal mutable durante el parseo. Una vez leídas todas las líneas
+     * de un código postal, {@link #toImmutable()} produce el {@link ZipCode} final.
+     */
+    private static final class Accumulator {
+        private final String zipCode;
+        private final String locality;
+        private final String federalEntity;
+        private final String municipality;
+        private final String normalizedFederalEntity;
+        private final String normalizedMunicipality;
+        private final List<Settlements> settlements = new ArrayList<>();
+
+        private Accumulator(String zipCode,
+                            String locality,
+                            String federalEntity,
+                            String municipality,
+                            String normalizedFederalEntity,
+                            String normalizedMunicipality) {
+            this.zipCode = zipCode;
+            this.locality = locality;
+            this.federalEntity = federalEntity;
+            this.municipality = municipality;
+            this.normalizedFederalEntity = normalizedFederalEntity;
+            this.normalizedMunicipality = normalizedMunicipality;
+        }
+
+        private ZipCode toImmutable() {
+            return ZipCode.builder()
+                    .zipCode(zipCode)
+                    .locality(locality)
+                    .federalEntity(federalEntity)
+                    .municipality(municipality)
+                    .settlements(List.copyOf(settlements))
+                    .normalizedFederalEntity(normalizedFederalEntity)
+                    .normalizedMunicipality(normalizedMunicipality)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeData.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeData.java
@@ -1,0 +1,27 @@
+package com.coderalexis.CodigoPostalApi.service;
+
+import com.coderalexis.CodigoPostalApi.model.ZipCode;
+
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+
+/**
+ * Resultado inmutable de la carga del catálogo SEPOMEX: las cuatro estructuras
+ * de índice que {@link ZipCodeService} sirve en modo solo-lectura. Producirlas
+ * en {@link SepomexZipCodeLoader} y entregarlas ya construidas (#10) separa la
+ * carga/parseo de la lógica de consulta.
+ *
+ * <ul>
+ *   <li>{@code byCode} - lookup directo O(1) por código postal</li>
+ *   <li>{@code sorted} - búsqueda por prefijo O(log n + k) vía {@code subMap()}</li>
+ *   <li>{@code byNormalizedEntity} - índice invertido por entidad federativa normalizada</li>
+ *   <li>{@code byNormalizedMunicipality} - índice invertido por municipio normalizado</li>
+ * </ul>
+ */
+public record ZipCodeData(
+        Map<String, ZipCode> byCode,
+        NavigableMap<String, ZipCode> sorted,
+        Map<String, Set<ZipCode>> byNormalizedEntity,
+        Map<String, Set<ZipCode>> byNormalizedMunicipality) {
+}

--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
@@ -8,27 +8,17 @@ import com.coderalexis.CodigoPostalApi.model.PagedResponse;
 import com.coderalexis.CodigoPostalApi.model.Settlements;
 import com.coderalexis.CodigoPostalApi.model.ZipCode;
 import com.coderalexis.CodigoPostalApi.model.ZipCodeStats;
+import com.coderalexis.CodigoPostalApi.util.PaginationSupport;
 import com.coderalexis.CodigoPostalApi.util.Util;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,44 +29,31 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
+/**
+ * Lógica de consulta de códigos postales sobre los índices en memoria. La carga
+ * y el parseo del catálogo se delegan en {@link SepomexZipCodeLoader} (#10) y la
+ * mecánica de paginación en {@link PaginationSupport}, dejando esta clase enfocada
+ * en las búsquedas y sus métricas/caché.
+ */
 @Service
 @Slf4j
 public class ZipCodeService {
-    // Pre-compiled Pattern for splitting lines (avoids recompiling on every split call)
-    private static final Pattern PIPE_PATTERN = Pattern.compile("\\|");
 
-    // Column indices based on CPdescarga.txt structure
-    private static final int COL_ZIP_CODE = 0;
-    private static final int COL_SETTLEMENT_NAME = 1;
-    private static final int COL_SETTLEMENT_TYPE = 2;
-    private static final int COL_MUNICIPALITY = 3;
-    private static final int COL_FEDERAL_ENTITY = 4;
-    private static final int COL_LOCALITY = 5;
-    private static final int COL_ZONE_TYPE_INDEX = 13;
-    private static final int MIN_COLUMNS = 6;
-    private static final int MAX_ERRORS_THRESHOLD = 100;
     private static final int PARTIAL_SEARCH_MAX_LIMIT = 50;
-
-    private static final Pattern ZIP_CODE_PATTERN =
-        Pattern.compile("^\\d{5}$");
     // Pre-compiled pattern for validating digit-only input (avoids recompiling on every partial search)
     private static final Pattern DIGITS_PATTERN = Pattern.compile("^\\d+$");
 
-    // Data is loaded once at startup and then treated as read-only. Non-concurrent
-    // collections avoid unnecessary synchronization overhead on the hot read path.
-    private final Map<String, ZipCode> zipCodesByCode = new HashMap<>();
-    // Sorted map for O(log n) prefix searches instead of O(n) full scan
-    private final NavigableMap<String, ZipCode> zipCodesSorted = new TreeMap<>();
-    // Inverted indices for fast searches by entity and municipality
-    private final Map<String, Set<ZipCode>> zipCodesByNormalizedEntity = new HashMap<>();
-    private final Map<String, Set<ZipCode>> zipCodesByNormalizedMunicipality = new HashMap<>();
+    // Índices cargados una vez al arranque y tratados como solo-lectura. Se publican
+    // como volatile: la escritura de la referencia (en loadZipCodes) establece un
+    // happens-before con cualquier lectura posterior desde los hilos de request.
+    private volatile Map<String, ZipCode> zipCodesByCode = Map.of();
+    private volatile NavigableMap<String, ZipCode> zipCodesSorted = Collections.emptyNavigableMap();
+    private volatile Map<String, Set<ZipCode>> zipCodesByNormalizedEntity = Map.of();
+    private volatile Map<String, Set<ZipCode>> zipCodesByNormalizedMunicipality = Map.of();
 
     // Pre-computed statistics (immutable after load)
     private volatile ZipCodeStats cachedStats;
@@ -101,17 +78,13 @@ public class ZipCodeService {
             .build();
 
     private volatile boolean dataLoaded = false;
-    private int errorCount = 0;
 
     private final MetricsConfiguration metricsConfiguration;
+    private final SepomexZipCodeLoader loader;
 
-    @Value("${zipcode.file.path}")
-    private String filePath;
-
-    private static final String RESOURCE_FILE = "CPdescarga.txt";
-
-    public ZipCodeService(MetricsConfiguration metricsConfiguration) {
+    public ZipCodeService(MetricsConfiguration metricsConfiguration, SepomexZipCodeLoader loader) {
         this.metricsConfiguration = metricsConfiguration;
+        this.loader = loader;
     }
 
     public boolean isDataLoaded() {
@@ -141,37 +114,44 @@ public class ZipCodeService {
 
     @PostConstruct
     public void loadZipCodes() {
-        try (InputStream stream = getInputStream()) {
-            if (stream == null) {
-                log.error("No se pudo cargar ningun archivo de codigos postales");
-                return;
-            }
-
-            processZipCodeFile(stream);
-            buildPreComputedData();
-            // Fix #2: marcamos dataLoaded sólo DESPUÉS de que las estructuras
-            // precomputadas (cachedStats, cachedFederalEntities,
-            // municipalitiesByNormalizedEntity) estén completas. De lo contrario
-            // un caller temprano podría ver dataLoaded=true pero campos null.
-            dataLoaded = true;
+        // Fail-fast: si el catálogo no puede cargarse, abortamos el arranque en vez
+        // de dejar el proceso vivo sirviendo 500 (NPE en los getters precomputados)
+        // y 200 con cuerpos nulos. Para una API cuyo único propósito son estos datos,
+        // es preferible que el orquestador (Railway/k8s) reinicie el contenedor.
+        ZipCodeData data;
+        try {
+            data = loader.load();
         } catch (IOException e) {
-            log.error("Error al cargar los codigos postales", e);
+            throw new IllegalStateException("Error al cargar los codigos postales", e);
         }
+
+        if (data == null || data.byCode().isEmpty()) {
+            throw new IllegalStateException(
+                    "No se pudo cargar el catalogo de codigos postales o quedo vacio; abortando el arranque");
+        }
+
+        this.zipCodesByCode = data.byCode();
+        this.zipCodesSorted = data.sorted();
+        this.zipCodesByNormalizedEntity = data.byNormalizedEntity();
+        this.zipCodesByNormalizedMunicipality = data.byNormalizedMunicipality();
+
+        buildPreComputedData();
+
+        // Fix #2: marcamos dataLoaded sólo DESPUÉS de que las estructuras
+        // precomputadas (cachedStats, cachedFederalEntities,
+        // municipalitiesByNormalizedEntity) estén completas.
+        dataLoaded = true;
     }
 
     private void buildPreComputedData() {
-        // Make all settlement lists immutable to prevent accidental mutation of internal state.
-        // Single pass (#10): durante esta pasada también acumulamos totalSettlements
-        // y la lista de FederalEntity para evitar recorrer el mapa varias veces.
+        // Single pass (#10): durante esta pasada acumulamos totalSettlements y la
+        // lista de FederalEntity para evitar recorrer el mapa varias veces.
         long totalSettlements = 0L;
         Map<String, List<ZipCode>> zipCodesByEntity = new HashMap<>();
         Map<String, Set<String>> municipalitiesByEntity = new HashMap<>();
 
         for (ZipCode zc : zipCodesByCode.values()) {
-            if (zc.getSettlements() != null) {
-                zc.setSettlements(List.copyOf(zc.getSettlements()));
-                totalSettlements += zc.getSettlements().size();
-            }
+            totalSettlements += zc.getSettlements().size();
 
             zipCodesByEntity
                     .computeIfAbsent(zc.getFederalEntity(), k -> new ArrayList<>())
@@ -181,7 +161,6 @@ public class ZipCodeService {
                     .computeIfAbsent(zc.getNormalizedFederalEntity(), k -> new TreeSet<>())
                     .add(zc.getMunicipality());
         }
-        log.info("  - Listas de asentamientos convertidas a inmutables");
 
         cachedStats = ZipCodeStats.builder()
                 .totalZipCodes(zipCodesByCode.size())
@@ -220,242 +199,6 @@ public class ZipCodeService {
     }
 
     /**
-     * Resuelve el InputStream del catálogo SEPOMEX.
-     *
-     * <p>Fix #20: si el usuario configura un path explícito (vía
-     * {@code zipcode.file.path}) y éste no existe, fallamos rápido en vez de
-     * caer silenciosamente al recurso interno, que enmascaraba problemas de
-     * despliegue (config incorrecta sin error visible).</p>
-     */
-    private InputStream getInputStream() throws IOException {
-        boolean userConfiguredPath = filePath != null && !filePath.isBlank();
-
-        if (userConfiguredPath && filePath.startsWith("classpath:")) {
-            String resourcePath = filePath.substring("classpath:".length());
-            ClassPathResource resource = new ClassPathResource(resourcePath);
-            if (resource.exists()) {
-                log.info("Cargando codigos postales desde classpath: {}", resourcePath);
-                return resource.getInputStream();
-            }
-            throw new IOException(
-                "Recurso configurado en 'zipcode.file.path' no encontrado en classpath: " + resourcePath);
-        }
-
-        if (userConfiguredPath) {
-            Path path = Paths.get(filePath);
-            if (Files.exists(path)) {
-                log.info("Cargando codigos postales desde {}", filePath);
-                return Files.newInputStream(path);
-            }
-            throw new IOException(
-                "Archivo configurado en 'zipcode.file.path' no encontrado: " + filePath);
-        }
-
-        ClassPathResource resource = new ClassPathResource(RESOURCE_FILE);
-        if (resource.exists()) {
-            log.info("Cargando codigos postales desde recurso interno {}", RESOURCE_FILE);
-            return resource.getInputStream();
-        }
-
-        return null;
-    }
-
-    private void processZipCodeFile(InputStream stream) throws IOException {
-        long startTime = System.currentTimeMillis();
-        errorCount = 0;
-
-        BufferedInputStream bufferedStream = new BufferedInputStream(stream);
-        Charset charset = detectCharset(bufferedStream);
-        log.info("Encoding detectado: {}", charset.name());
-
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(bufferedStream, charset))) {
-
-            // Skip first two lines (metadata and header)
-            reader.readLine();
-            reader.readLine();
-
-            long linesProcessed = reader.lines()
-                    .filter(this::processLine)
-                    .count();
-
-            long duration = System.currentTimeMillis() - startTime;
-
-            log.info("Datos cargados exitosamente en {}ms", duration);
-            log.info("  - Codigos postales unicos: {}", zipCodesByCode.size());
-            log.info("  - Entidades federativas: {}", zipCodesByNormalizedEntity.size());
-            log.info("  - Municipios: {}", zipCodesByNormalizedMunicipality.size());
-            log.info("  - Lineas procesadas: {}", linesProcessed);
-            if (errorCount > 0) {
-                log.warn("  - Lineas con errores: {}", errorCount);
-            }
-        }
-    }
-
-    private Charset detectCharset(BufferedInputStream stream) throws IOException {
-        stream.mark(4096);
-        byte[] sample = new byte[4096];
-        int bytesRead = stream.read(sample);
-        stream.reset();
-
-        if (bytesRead <= 0) {
-            return StandardCharsets.UTF_8;
-        }
-
-        boolean hasHighBytes = false;
-        boolean hasUtf8Sequences = false;
-
-        for (int i = 0; i < bytesRead; i++) {
-            int b = sample[i] & 0xFF;
-            if (b >= 0x80) {
-                hasHighBytes = true;
-                if ((b & 0xE0) == 0xC0 || (b & 0xF0) == 0xE0) {
-                    if (i + 1 < bytesRead && (sample[i + 1] & 0xC0) == 0x80) {
-                        hasUtf8Sequences = true;
-                    }
-                }
-            }
-        }
-
-        if (hasHighBytes && !hasUtf8Sequences) {
-            log.debug("Detectado encoding ISO-8859-1 (bytes altos sin secuencias UTF-8)");
-            return StandardCharsets.ISO_8859_1;
-        }
-
-        if (hasUtf8Sequences) {
-            log.debug("Detectado encoding UTF-8 (secuencias UTF-8 validas encontradas)");
-            return StandardCharsets.UTF_8;
-        }
-
-        log.debug("Usando encoding por defecto ISO-8859-1 para archivo SEPOMEX");
-        return StandardCharsets.ISO_8859_1;
-    }
-
-    private boolean processLine(String line) {
-        try {
-            String[] words = PIPE_PATTERN.split(line);
-
-            if (words.length < MIN_COLUMNS) {
-                handleError("Linea con formato incorrecto (columnas insuficientes): {}",
-                    line.substring(0, Math.min(100, line.length())));
-                return false;
-            }
-
-            String zipCodeKey = words[COL_ZIP_CODE].trim();
-
-            if (!isValidZipCode(zipCodeKey)) {
-                handleError("Codigo postal invalido '{}' en linea: {}",
-                    zipCodeKey, line.substring(0, Math.min(100, line.length())));
-                return false;
-            }
-
-            if (words[COL_FEDERAL_ENTITY].trim().isEmpty() ||
-                words[COL_MUNICIPALITY].trim().isEmpty()) {
-                handleError("Campos requeridos vacios en codigo postal: {}", zipCodeKey);
-                return false;
-            }
-
-            String federalEntity = words[COL_FEDERAL_ENTITY].trim();
-            String municipality = words[COL_MUNICIPALITY].trim();
-            String normalizedEntity = Util.normalizeString(federalEntity);
-            String normalizedMunicipality = Util.normalizeString(municipality);
-
-            ZipCode zipCode = zipCodesByCode.computeIfAbsent(zipCodeKey, k -> {
-                ZipCode z = new ZipCode();
-                z.setZipCode(k);
-                z.setLocality(words[COL_LOCALITY].trim());
-                z.setFederalEntity(federalEntity);
-                z.setMunicipality(municipality);
-                z.setNormalizedFederalEntity(normalizedEntity);
-                z.setNormalizedMunicipality(normalizedMunicipality);
-                z.setSettlements(new ArrayList<>());
-
-                // Add to sorted map for prefix searches
-                zipCodesSorted.put(k, z);
-                return z;
-            });
-
-            String settlementName = words[COL_SETTLEMENT_NAME].trim();
-            String settlementTypeVal = words[COL_SETTLEMENT_TYPE].trim();
-            String zoneTypeVal = words.length > COL_ZONE_TYPE_INDEX ?
-                words[COL_ZONE_TYPE_INDEX].trim() : "";
-
-            // Fix #18: Settlements ahora es un record inmutable, construido en una
-            // sola expresión con los campos normalizados precomputados.
-            Settlements settlement = new Settlements(
-                    settlementName,
-                    zoneTypeVal,
-                    settlementTypeVal,
-                    Util.normalizeString(settlementName),
-                    Util.normalizeString(settlementTypeVal),
-                    Util.normalizeString(zoneTypeVal));
-
-            zipCode.getSettlements().add(settlement);
-
-            zipCodesByNormalizedEntity
-                    .computeIfAbsent(normalizedEntity, k -> new HashSet<>())
-                    .add(zipCode);
-
-            zipCodesByNormalizedMunicipality
-                    .computeIfAbsent(normalizedMunicipality, k -> new HashSet<>())
-                    .add(zipCode);
-
-            return true;
-
-        } catch (Exception e) {
-            handleError("Error procesando la linea: {}",
-                line.substring(0, Math.min(100, line.length())));
-            log.debug("Detalle del error:", e);
-            return false;
-        }
-    }
-
-    private void handleError(String message, Object... args) {
-        errorCount++;
-        if (errorCount <= MAX_ERRORS_THRESHOLD) {
-            log.warn(message, args);
-        } else if (errorCount == MAX_ERRORS_THRESHOLD + 1) {
-            log.warn("Se alcanzo el limite de {} errores. Los siguientes errores no se mostraran.", MAX_ERRORS_THRESHOLD);
-        }
-    }
-
-    private boolean isValidZipCode(String zipCode) {
-        return zipCode != null && ZIP_CODE_PATTERN.matcher(zipCode).matches();
-    }
-
-    /**
-     * @deprecated Usar la variante paginada {@link #searchByFederalEntity(String, int, int)}.
-     * Este método materializa todos los ZipCodes coincidentes (que para una entidad como
-     * "Ciudad de México" pueden ser ≥25 000) y los retiene en cache; el controlador
-     * siempre llama a la versión paginada. Se mantiene sólo por compatibilidad de tests.
-     */
-    @Deprecated(forRemoval = false)
-    @Cacheable(value = "federalEntitySearch", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#searchTerm)")
-    public List<ZipCode> searchByFederalEntity(String searchTerm) {
-        Timer.Sample sample = metricsConfiguration.startTimer();
-        try {
-            metricsConfiguration.recordSearch("federal_entity");
-            String normalizedSearchTerm = validateSearchTerm(searchTerm, "federal_entity");
-
-            List<ZipCode> results = findOrderedCandidatesInIndex(
-                    zipCodesByNormalizedEntity,
-                    normalizedSearchTerm);
-
-            if (results.isEmpty()) {
-                metricsConfiguration.recordSearchError("federal_entity", "not_found");
-                throw new ZipCodeNotFoundException(
-                        "No se encontraron codigos postales para la entidad federativa: " + searchTerm
-                );
-            }
-
-            metricsConfiguration.recordResultSize("federal_entity", results.size());
-            return results;
-        } finally {
-            metricsConfiguration.recordSearchDuration(sample, "federal_entity");
-        }
-    }
-
-    /**
      * Búsqueda paginada por entidad federativa. Fix #8: ordena el conjunto
      * (vía índice invertido) y materializa sólo la página solicitada en vez
      * de la lista completa.
@@ -465,7 +208,7 @@ public class ZipCodeService {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
             metricsConfiguration.recordSearch("federal_entity");
-            validatePagination(page, size);
+            PaginationSupport.validatePagination(page, size);
             String normalizedSearchTerm = validateSearchTerm(searchTerm, "federal_entity");
 
             Set<ZipCode> matches = findCandidatesInIndex(zipCodesByNormalizedEntity, normalizedSearchTerm);
@@ -476,7 +219,7 @@ public class ZipCodeService {
                 );
             }
 
-            PagedResponse<ZipCode> response = paginateSorted(
+            PagedResponse<ZipCode> response = PaginationSupport.paginateSorted(
                     matches,
                     Comparator.comparing(ZipCode::getZipCode),
                     page,
@@ -490,35 +233,6 @@ public class ZipCodeService {
     }
 
     /**
-     * @deprecated Usar la variante paginada {@link #searchByMunicipality(String, int, int)}.
-     */
-    @Deprecated(forRemoval = false)
-    @Cacheable(value = "municipalitySearch", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#searchTerm)")
-    public List<ZipCode> searchByMunicipality(String searchTerm) {
-        Timer.Sample sample = metricsConfiguration.startTimer();
-        try {
-            metricsConfiguration.recordSearch("municipality");
-            String normalizedSearchTerm = validateSearchTerm(searchTerm, "municipality");
-
-            List<ZipCode> results = findOrderedCandidatesInIndex(
-                    zipCodesByNormalizedMunicipality,
-                    normalizedSearchTerm);
-
-            if (results.isEmpty()) {
-                metricsConfiguration.recordSearchError("municipality", "not_found");
-                throw new ZipCodeNotFoundException(
-                        "No se encontraron codigos postales para el municipio: " + searchTerm
-                );
-            }
-
-            metricsConfiguration.recordResultSize("municipality", results.size());
-            return results;
-        } finally {
-            metricsConfiguration.recordSearchDuration(sample, "municipality");
-        }
-    }
-
-    /**
      * Búsqueda paginada por municipio. Fix #8: idem entidad federativa.
      */
     @Cacheable(value = "municipalitySearchPaged", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#searchTerm) + '_' + #page + '_' + #size")
@@ -526,7 +240,7 @@ public class ZipCodeService {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
             metricsConfiguration.recordSearch("municipality");
-            validatePagination(page, size);
+            PaginationSupport.validatePagination(page, size);
             String normalizedSearchTerm = validateSearchTerm(searchTerm, "municipality");
 
             Set<ZipCode> matches = findCandidatesInIndex(zipCodesByNormalizedMunicipality, normalizedSearchTerm);
@@ -537,7 +251,7 @@ public class ZipCodeService {
                 );
             }
 
-            PagedResponse<ZipCode> response = paginateSorted(
+            PagedResponse<ZipCode> response = PaginationSupport.paginateSorted(
                     matches,
                     Comparator.comparing(ZipCode::getZipCode),
                     page,
@@ -558,7 +272,8 @@ public class ZipCodeService {
     }
 
     /**
-     * Prefix search using ConcurrentSkipListMap.subMap() for O(log n + k) performance.
+     * Prefix search using the sorted {@link NavigableMap#subMap} for O(log n + k)
+     * performance.
      *
      * <p>Fix #5: la cache ahora se llava SÓLO por el prefijo normalizado. Para
      * cada prefijo cacheamos hasta {@link #PARTIAL_SEARCH_MAX_LIMIT} resultados
@@ -633,8 +348,10 @@ public class ZipCodeService {
 
     /**
      * Returns pre-computed federal entities list (calculated once at startup).
+     * No usa {@code @Cacheable}: el resultado ya es un campo inmutable en memoria,
+     * así que el proxy + lookup de caché sólo añadiría overhead y, además,
+     * impediría registrar métricas en los hits de caché.
      */
-    @Cacheable(value = "federalEntities")
     public List<FederalEntity> getAllFederalEntities() {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
@@ -687,40 +404,6 @@ public class ZipCodeService {
     }
 
     /**
-     * @deprecated Usar la variante paginada {@link #advancedSearch(AdvancedSearchRequest, int, int)}.
-     * Materializar toda la lista en cache puede tener un costo de memoria significativo.
-     */
-    @Deprecated(forRemoval = false)
-    @Cacheable(
-            value = "advancedSearch",
-            key = "#request.normalizedFilterCacheKey()",
-            // Fix #19: evita ocupar slot de cache con requests inválidos (null o
-            // todos los filtros vacíos) que terminarán en IllegalArgumentException.
-            condition = "#request != null && #request.hasAnyFilter()")
-    public List<ZipCode> advancedSearch(AdvancedSearchRequest request) {
-        Timer.Sample sample = metricsConfiguration.startTimer();
-        try {
-            AdvancedSearchCriteria criteria = validateAndNormalizeAdvancedSearchRequest(request);
-            Collection<ZipCode> candidates = resolveOrderedSearchCandidates(criteria);
-            Predicate<ZipCode> filter = zipCode -> matchesAdvancedCriteria(zipCode, criteria);
-
-            List<ZipCode> results = candidates.stream()
-                    .filter(filter)
-                    .collect(Collectors.toList());
-
-            if (results.isEmpty()) {
-                metricsConfiguration.recordSearchError("advanced", "not_found");
-                throw new ZipCodeNotFoundException("No se encontraron codigos postales con los criterios especificados");
-            }
-
-            metricsConfiguration.recordResultSize("advanced", results.size());
-            return results;
-        } finally {
-            metricsConfiguration.recordSearchDuration(sample, "advanced");
-        }
-    }
-
-    /**
      * Paginated advanced search that materializes only the requested page.
      * This keeps broad advanced searches from allocating all matching ZipCode
      * objects when clients only need one page.
@@ -732,11 +415,11 @@ public class ZipCodeService {
     public PagedResponse<ZipCode> advancedSearch(AdvancedSearchRequest request, int page, int size) {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
-            validatePagination(page, size);
+            PaginationSupport.validatePagination(page, size);
             AdvancedSearchCriteria criteria = validateAndNormalizeAdvancedSearchRequest(request);
             Collection<ZipCode> candidates = resolveOrderedSearchCandidates(criteria);
 
-            PagedResponse<ZipCode> response = createPagedResponse(
+            PagedResponse<ZipCode> response = PaginationSupport.paginateFiltered(
                     candidates,
                     zipCode -> matchesAdvancedCriteria(zipCode, criteria),
                     page,
@@ -846,120 +529,6 @@ public class ZipCodeService {
             String normalizedZoneType) {
     }
 
-    /**
-     * Creates a paginated response from a list of results.
-     * Uses long arithmetic to prevent overflow when page * size exceeds Integer.MAX_VALUE.
-     */
-    public static <T> PagedResponse<T> createPagedResponse(List<T> allResults, int page, int size) {
-        validatePagination(page, size);
-
-        int totalElements = allResults.size();
-        int totalPages = calculateTotalPages(totalElements, size);
-        long offset = (long) page * size;
-
-        if (offset >= totalElements) {
-            return buildPagedResponse(List.of(), page, size, totalElements, totalPages);
-        }
-
-        int start = (int) offset; // Safe: offset < totalElements which is an int
-        int end = Math.min(start + size, totalElements);
-        return buildPagedResponse(allResults.subList(start, end), page, size, totalElements, totalPages);
-    }
-
-    /**
-     * Streaming pagination que ordena el conjunto candidato y materializa
-     * únicamente la página solicitada. Fix #8.
-     */
-    private static <T> PagedResponse<T> paginateSorted(
-            Set<T> candidates,
-            Comparator<T> comparator,
-            int page,
-            int size) {
-        validatePagination(page, size);
-
-        int totalElements = candidates.size();
-        int totalPages = calculateTotalPages(totalElements, size);
-        long offset = (long) page * size;
-
-        if (offset >= totalElements) {
-            return buildPagedResponse(List.of(), page, size, totalElements, totalPages);
-        }
-
-        int start = (int) offset;
-        int limit = Math.min(size, totalElements - start);
-        List<T> pageContent = candidates.stream()
-                .sorted(comparator)
-                .skip(start)
-                .limit(limit)
-                .toList();
-
-        return buildPagedResponse(pageContent, page, size, totalElements, totalPages);
-    }
-
-    /**
-     * Creates a paginated response from a collection without materializing the full
-     * filtered result set. The collection iteration order is preserved.
-     */
-    private static <T> PagedResponse<T> createPagedResponse(
-            Collection<T> candidates,
-            Predicate<T> filter,
-            int page,
-            int size) {
-        validatePagination(page, size);
-
-        long offset = (long) page * size;
-        List<T> pageContent = new ArrayList<>(size);
-        int totalElements = 0;
-
-        for (T candidate : candidates) {
-            if (!filter.test(candidate)) {
-                continue;
-            }
-
-            if (totalElements >= offset && pageContent.size() < size) {
-                pageContent.add(candidate);
-            }
-            totalElements++;
-        }
-
-        return buildPagedResponse(
-                pageContent,
-                page,
-                size,
-                totalElements,
-                calculateTotalPages(totalElements, size));
-    }
-
-    private static <T> PagedResponse<T> buildPagedResponse(
-            List<T> content,
-            int page,
-            int size,
-            int totalElements,
-            int totalPages) {
-        return PagedResponse.<T>builder()
-                .content(content)
-                .pageNumber(page)
-                .pageSize(size)
-                .totalElements(totalElements)
-                .totalPages(totalPages)
-                .first(page == 0)
-                .last(totalPages == 0 || page >= totalPages - 1)
-                .build();
-    }
-
-    private static int calculateTotalPages(int totalElements, int size) {
-        return totalElements == 0 ? 0 : (int) Math.ceil((double) totalElements / size);
-    }
-
-    private static void validatePagination(int page, int size) {
-        if (page < 0) {
-            throw new IllegalArgumentException("La pagina debe ser mayor o igual a 0");
-        }
-        if (size < 1) {
-            throw new IllegalArgumentException("El tamaño debe ser mayor a 0");
-        }
-    }
-
     private String validateSearchTerm(String searchTerm, String searchType) {
         if (searchTerm == null || searchTerm.trim().isEmpty()) {
             metricsConfiguration.recordSearchError(searchType, "empty_search");
@@ -997,23 +566,6 @@ public class ZipCodeService {
 
         // Fallback: full scan in deterministic zip-code order only when filtering by settlement/type/zone.
         return zipCodesSorted.values();
-    }
-
-    /**
-     * Devuelve todos los ZipCodes coincidentes (en orden ascendente por código
-     * postal) recorriendo el índice invertido. {@code distinct()} es defensivo:
-     * cada ZipCode aparece sólo bajo una clave por dimensión (porque cada CP
-     * tiene una sola entidad/municipio), así que en práctica nunca hay
-     * duplicados. Conservamos {@code distinct()} para que el contrato sea
-     * robusto si en el futuro se admiten múltiples valores por ZipCode.
-     */
-    private List<ZipCode> findOrderedCandidatesInIndex(Map<String, Set<ZipCode>> index, String normalizedSearchTerm) {
-        return index.entrySet().stream()
-                .filter(entry -> entry.getKey().contains(normalizedSearchTerm))
-                .flatMap(entry -> entry.getValue().stream())
-                .distinct()
-                .sorted(Comparator.comparing(ZipCode::getZipCode))
-                .toList();
     }
 
     private Set<ZipCode> findCandidatesInIndex(Map<String, Set<ZipCode>> index, String normalizedSearchTerm) {

--- a/src/main/java/com/coderalexis/CodigoPostalApi/util/PaginationSupport.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/util/PaginationSupport.java
@@ -1,0 +1,137 @@
+package com.coderalexis.CodigoPostalApi.util;
+
+import com.coderalexis.CodigoPostalApi.model.PagedResponse;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Utilidades genéricas de paginación, extraídas de {@code ZipCodeService} (#10)
+ * para separar la mecánica de paginación de la lógica de negocio y poder
+ * reutilizarlas/probarlas de forma aislada.
+ *
+ * <p>Todas las variantes usan aritmética en {@code long} para el offset, de modo
+ * que {@code page * size} no desborde {@link Integer#MAX_VALUE}.</p>
+ */
+public final class PaginationSupport {
+
+    private PaginationSupport() {
+    }
+
+    /**
+     * Pagina una lista ya materializada tomando una sublista de la página pedida.
+     */
+    public static <T> PagedResponse<T> paginate(List<T> allResults, int page, int size) {
+        validatePagination(page, size);
+
+        int totalElements = allResults.size();
+        int totalPages = calculateTotalPages(totalElements, size);
+        long offset = (long) page * size;
+
+        if (offset >= totalElements) {
+            return buildPagedResponse(List.of(), page, size, totalElements, totalPages);
+        }
+
+        int start = (int) offset; // Safe: offset < totalElements which is an int
+        int end = Math.min(start + size, totalElements);
+        return buildPagedResponse(allResults.subList(start, end), page, size, totalElements, totalPages);
+    }
+
+    /**
+     * Ordena el conjunto candidato con el comparador dado y materializa
+     * únicamente la página solicitada.
+     */
+    public static <T> PagedResponse<T> paginateSorted(
+            Set<T> candidates,
+            Comparator<T> comparator,
+            int page,
+            int size) {
+        validatePagination(page, size);
+
+        int totalElements = candidates.size();
+        int totalPages = calculateTotalPages(totalElements, size);
+        long offset = (long) page * size;
+
+        if (offset >= totalElements) {
+            return buildPagedResponse(List.of(), page, size, totalElements, totalPages);
+        }
+
+        int start = (int) offset;
+        int limit = Math.min(size, totalElements - start);
+        List<T> pageContent = candidates.stream()
+                .sorted(comparator)
+                .skip(start)
+                .limit(limit)
+                .toList();
+
+        return buildPagedResponse(pageContent, page, size, totalElements, totalPages);
+    }
+
+    /**
+     * Pagina una colección aplicando un filtro al vuelo, sin materializar el
+     * conjunto filtrado completo. Se preserva el orden de iteración de la colección.
+     */
+    public static <T> PagedResponse<T> paginateFiltered(
+            Collection<T> candidates,
+            Predicate<T> filter,
+            int page,
+            int size) {
+        validatePagination(page, size);
+
+        long offset = (long) page * size;
+        List<T> pageContent = new ArrayList<>(size);
+        int totalElements = 0;
+
+        for (T candidate : candidates) {
+            if (!filter.test(candidate)) {
+                continue;
+            }
+
+            if (totalElements >= offset && pageContent.size() < size) {
+                pageContent.add(candidate);
+            }
+            totalElements++;
+        }
+
+        return buildPagedResponse(
+                pageContent,
+                page,
+                size,
+                totalElements,
+                calculateTotalPages(totalElements, size));
+    }
+
+    public static void validatePagination(int page, int size) {
+        if (page < 0) {
+            throw new IllegalArgumentException("La pagina debe ser mayor o igual a 0");
+        }
+        if (size < 1) {
+            throw new IllegalArgumentException("El tamaño debe ser mayor a 0");
+        }
+    }
+
+    private static <T> PagedResponse<T> buildPagedResponse(
+            List<T> content,
+            int page,
+            int size,
+            int totalElements,
+            int totalPages) {
+        return PagedResponse.<T>builder()
+                .content(content)
+                .pageNumber(page)
+                .pageSize(size)
+                .totalElements(totalElements)
+                .totalPages(totalPages)
+                .first(page == 0)
+                .last(totalPages == 0 || page >= totalPages - 1)
+                .build();
+    }
+
+    private static int calculateTotalPages(int totalElements, int size) {
+        return totalElements == 0 ? 0 : (int) Math.ceil((double) totalElements / size);
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -71,3 +71,11 @@ server:
     min-response-size: 512  # Comprimir respuestas > 512 bytes
   # Seguridad adicional
   shutdown: graceful  # Apagado graceful
+
+# Documentación OpenAPI deshabilitada en producción: no exponer el contrato ni el
+# Swagger UI públicamente. (SpringDoc los habilita por defecto y lo advierte en logs.)
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/src/main/resources/application-qa.yml
+++ b/src/main/resources/application-qa.yml
@@ -8,12 +8,9 @@ spring:
   config:
     activate:
       on-profile: qa
-  # Caché con TTL más corto para pruebas (consolidado en un único bloque spring:
-  # para evitar duplicación de claves YAML, que SnakeYAML resuelve sobrescribiendo
-  # el primer bloque silenciosamente).
-  cache:
-    caffeine:
-      spec: maximumSize=5000,expireAfterAccess=10m
+  # NOTA: no se define spring.cache.caffeine.spec porque CacheConfiguration registra
+  # cada región con registerCustomCache(...), lo que ignora el spec global. Mantenerlo
+  # aquí sólo confundía (igual que ya se removió del perfil prod).
 
 # Rate limiting moderado para pruebas realistas
 ratelimit:

--- a/src/main/resources/application-railway.yml
+++ b/src/main/resources/application-railway.yml
@@ -65,3 +65,11 @@ logging:
 zipcode:
   file:
     path: classpath:CPdescarga.txt
+
+# Documentación OpenAPI deshabilitada en producción: no exponer el contrato ni el
+# Swagger UI públicamente. (SpringDoc los habilita por defecto y lo advierte en logs.)
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/src/main/resources/banner-dev.txt
+++ b/src/main/resources/banner-dev.txt
@@ -1,0 +1,13 @@
+${AnsiColor.BRIGHT_GREEN}
+   ____          _ _                ____           _        _
+  / ___|___   __| (_) __ _  ___    |  _ \ ___  ___| |_ __ _| |
+ | |   / _ \ / _` | |/ _` |/ _ \   | |_) / _ \/ __| __/ _` | |
+ | |__| (_) | (_| | | (_| | (_) |  |  __/ (_) \__ \ || (_| | |
+  \____\___/ \__,_|_|\__, |\___/   |_|   \___/|___/\__\__,_|_|
+                     |___/
+${AnsiColor.BRIGHT_YELLOW}        API de Códigos Postales de México  ::  PERFIL DEV
+${AnsiColor.BRIGHT_BLACK} ----------------------------------------------------------------
+${AnsiColor.DEFAULT}  Spring Boot   : ${spring-boot.formatted-version}
+  Perfil activo : ${spring.profiles.active:default}
+  Swagger UI    : http://localhost:8080/swagger-ui.html
+${AnsiColor.RESET}

--- a/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
@@ -55,13 +55,14 @@ class ZipCodeServiceTest {
     @Test
     @DisplayName("Debe buscar por entidad federativa")
     void shouldSearchByFederalEntity() {
-        List<ZipCode> results = zipCodeService.searchByFederalEntity("Ciudad de México");
+        PagedResponse<ZipCode> results = zipCodeService.searchByFederalEntity("Ciudad de México", 0, 50);
 
         assertNotNull(results, "Los resultados no deben ser null");
-        assertFalse(results.isEmpty(), "Debe encontrar resultados");
+        assertTrue(results.getTotalElements() > 0, "Debe encontrar resultados");
+        assertFalse(results.getContent().isEmpty(), "La primera página debe traer contenido");
 
         // Verificar que todos los resultados contienen la entidad buscada
-        results.forEach(zipCode -> {
+        results.getContent().forEach(zipCode -> {
             assertNotNull(zipCode.getFederalEntity());
             assertTrue(
                 zipCode.getFederalEntity().toLowerCase().contains("ciudad") ||
@@ -74,16 +75,16 @@ class ZipCodeServiceTest {
     @Test
     @DisplayName("Debe buscar por entidad federativa sin acentos")
     void shouldSearchByFederalEntityWithoutAccents() {
-        List<ZipCode> resultsWithAccents = zipCodeService.searchByFederalEntity("México");
-        List<ZipCode> resultsWithoutAccents = zipCodeService.searchByFederalEntity("Mexico");
+        PagedResponse<ZipCode> resultsWithAccents = zipCodeService.searchByFederalEntity("México", 0, 1);
+        PagedResponse<ZipCode> resultsWithoutAccents = zipCodeService.searchByFederalEntity("Mexico", 0, 1);
 
         assertNotNull(resultsWithAccents);
         assertNotNull(resultsWithoutAccents);
-        assertFalse(resultsWithAccents.isEmpty());
-        assertFalse(resultsWithoutAccents.isEmpty());
+        assertTrue(resultsWithAccents.getTotalElements() > 0);
+        assertTrue(resultsWithoutAccents.getTotalElements() > 0);
 
         // Ambas búsquedas deberían retornar la misma cantidad (normalización)
-        assertEquals(resultsWithAccents.size(), resultsWithoutAccents.size(),
+        assertEquals(resultsWithAccents.getTotalElements(), resultsWithoutAccents.getTotalElements(),
             "La búsqueda debe ser insensible a acentos");
     }
 
@@ -91,7 +92,7 @@ class ZipCodeServiceTest {
     @DisplayName("Debe lanzar excepción para entidad federativa no encontrada")
     void shouldThrowExceptionForInvalidFederalEntity() {
         assertThrows(ZipCodeNotFoundException.class, () -> {
-            zipCodeService.searchByFederalEntity("EntidadInexistente12345");
+            zipCodeService.searchByFederalEntity("EntidadInexistente12345", 0, 20);
         }, "Debe lanzar ZipCodeNotFoundException para entidad inexistente");
     }
 
@@ -100,7 +101,7 @@ class ZipCodeServiceTest {
     @DisplayName("Debe validar nulos antes de generar la llave de cache en entidad")
     void shouldValidateNullFederalEntityBeforeCacheKey() {
         assertThrows(IllegalArgumentException.class, () -> {
-            zipCodeService.searchByFederalEntity(null);
+            zipCodeService.searchByFederalEntity(null, 0, 20);
         }, "Debe lanzar IllegalArgumentException para término null");
     }
 
@@ -108,11 +109,11 @@ class ZipCodeServiceTest {
     @DisplayName("Debe lanzar excepción para término de búsqueda vacío en entidad")
     void shouldThrowExceptionForEmptyFederalEntitySearch() {
         assertThrows(IllegalArgumentException.class, () -> {
-            zipCodeService.searchByFederalEntity("");
+            zipCodeService.searchByFederalEntity("", 0, 20);
         }, "Debe lanzar IllegalArgumentException para término vacío");
 
         assertThrows(IllegalArgumentException.class, () -> {
-            zipCodeService.searchByFederalEntity("   ");
+            zipCodeService.searchByFederalEntity("   ", 0, 20);
         }, "Debe lanzar IllegalArgumentException para término solo con espacios");
     }
 
@@ -120,12 +121,12 @@ class ZipCodeServiceTest {
     @DisplayName("Debe buscar por municipio")
     void shouldSearchByMunicipality() {
         // Ajusta el municipio según tu archivo de prueba
-        List<ZipCode> results = zipCodeService.searchByMunicipality("Álvaro Obregón");
+        PagedResponse<ZipCode> results = zipCodeService.searchByMunicipality("Álvaro Obregón", 0, 50);
 
         assertNotNull(results, "Los resultados no deben ser null");
-        assertFalse(results.isEmpty(), "Debe encontrar resultados");
+        assertTrue(results.getTotalElements() > 0, "Debe encontrar resultados");
 
-        results.forEach(zipCode -> {
+        results.getContent().forEach(zipCode -> {
             assertNotNull(zipCode.getMunicipality());
         });
     }
@@ -133,23 +134,21 @@ class ZipCodeServiceTest {
     @Test
     @DisplayName("Debe buscar por municipio sin acentos")
     void shouldSearchByMunicipalityWithoutAccents() {
-        List<ZipCode> resultsWithAccents = zipCodeService.searchByMunicipality("Álvaro");
-        List<ZipCode> resultsWithoutAccents = zipCodeService.searchByMunicipality("Alvaro");
+        PagedResponse<ZipCode> resultsWithAccents = zipCodeService.searchByMunicipality("Álvaro", 0, 1);
+        PagedResponse<ZipCode> resultsWithoutAccents = zipCodeService.searchByMunicipality("Alvaro", 0, 1);
 
         assertNotNull(resultsWithAccents);
         assertNotNull(resultsWithoutAccents);
 
-        if (!resultsWithAccents.isEmpty() && !resultsWithoutAccents.isEmpty()) {
-            assertEquals(resultsWithAccents.size(), resultsWithoutAccents.size(),
-                "La búsqueda debe ser insensible a acentos");
-        }
+        assertEquals(resultsWithAccents.getTotalElements(), resultsWithoutAccents.getTotalElements(),
+            "La búsqueda debe ser insensible a acentos");
     }
 
     @Test
     @DisplayName("Debe lanzar excepción para municipio no encontrado")
     void shouldThrowExceptionForInvalidMunicipality() {
         assertThrows(ZipCodeNotFoundException.class, () -> {
-            zipCodeService.searchByMunicipality("MunicipioInexistente12345");
+            zipCodeService.searchByMunicipality("MunicipioInexistente12345", 0, 20);
         }, "Debe lanzar ZipCodeNotFoundException para municipio inexistente");
     }
 
@@ -157,21 +156,20 @@ class ZipCodeServiceTest {
     @DisplayName("Debe lanzar excepción para término de búsqueda vacío en municipio")
     void shouldThrowExceptionForEmptyMunicipalitySearch() {
         assertThrows(IllegalArgumentException.class, () -> {
-            zipCodeService.searchByMunicipality("");
+            zipCodeService.searchByMunicipality("", 0, 20);
         }, "Debe lanzar IllegalArgumentException para término vacío");
     }
 
     @Test
     @DisplayName("Debe paginar búsqueda por entidad federativa sin perder metadatos")
     void shouldPaginateFederalEntitySearch() {
-        List<ZipCode> allResults = zipCodeService.searchByFederalEntity("Ciudad de México");
         PagedResponse<ZipCode> firstPage = zipCodeService.searchByFederalEntity("Ciudad de México", 0, 5);
 
         assertNotNull(firstPage);
         assertEquals(0, firstPage.getPageNumber());
         assertEquals(5, firstPage.getPageSize());
-        assertEquals(allResults.size(), firstPage.getTotalElements());
-        assertEquals(Math.min(5, allResults.size()), firstPage.getContent().size());
+        assertTrue(firstPage.getTotalElements() > 0, "Debe conservar el total real de elementos");
+        assertEquals(Math.min(5, (int) firstPage.getTotalElements()), firstPage.getContent().size());
         assertTrue(firstPage.isFirst());
     }
 
@@ -235,20 +233,21 @@ class ZipCodeServiceTest {
     @Test
     @DisplayName("Debe buscar por búsqueda parcial en entidad federativa")
     void shouldSearchByPartialFederalEntity() {
-        List<ZipCode> results = zipCodeService.searchByFederalEntity("mex");
+        PagedResponse<ZipCode> results = zipCodeService.searchByFederalEntity("mex", 0, 20);
 
         assertNotNull(results);
-        assertFalse(results.isEmpty(), "Búsqueda parcial debe retornar resultados");
+        assertTrue(results.getTotalElements() > 0, "Búsqueda parcial debe retornar resultados");
     }
 
     @Test
     @DisplayName("Debe buscar por búsqueda parcial en municipio")
     void shouldSearchByPartialMunicipality() {
-        List<ZipCode> results = zipCodeService.searchByMunicipality("gua");
+        PagedResponse<ZipCode> results = zipCodeService.searchByMunicipality("gua", 0, 20);
 
         assertNotNull(results);
         // Este test puede pasar o fallar dependiendo del contenido del archivo
         // Si no hay municipios con "gua", ajusta el término de búsqueda
+        assertTrue(results.getTotalElements() > 0);
     }
 
     @Test
@@ -279,14 +278,13 @@ class ZipCodeServiceTest {
                 .zoneType("Urbano")
                 .build();
 
-        List<ZipCode> allResults = zipCodeService.advancedSearch(request);
         PagedResponse<ZipCode> firstPage = zipCodeService.advancedSearch(request, 0, 5);
 
         assertNotNull(firstPage);
         assertEquals(0, firstPage.getPageNumber());
         assertEquals(5, firstPage.getPageSize());
-        assertEquals(allResults.size(), firstPage.getTotalElements());
-        assertEquals(Math.min(5, allResults.size()), firstPage.getContent().size());
+        assertTrue(firstPage.getTotalElements() > 0, "Debe encontrar resultados con los filtros dados");
+        assertEquals(Math.min(5, (int) firstPage.getTotalElements()), firstPage.getContent().size());
         assertTrue(firstPage.getContent().stream()
                 .allMatch(zipCode -> zipCode.getZipCode().compareTo("00000") >= 0));
     }


### PR DESCRIPTION
Ronda de mejoras de robustez, limpieza y estructura. La suite completa (66 tests) permanece verde.

Robustez / config:
- ZipCodeService: la carga es fail-fast — si el catálogo no se encuentra o queda vacío se aborta el arranque (IllegalStateException) en vez de dejar el servicio vivo-pero-roto (NPE en /federal-entities, 200 con cuerpo nulo en /stats).
- prod/railway: deshabilita springdoc api-docs y swagger-ui.
- qa: elimina spring.cache.caffeine.spec (ignorado por registerCustomCache).
- Añade banner-dev.txt (estaba referenciado pero no existía).

Limpieza:
- Elimina los métodos @Deprecated de 1 argumento (search*/advancedSearch), el helper findOrderedCandidatesInIndex y las 3 regiones de caché no paginadas; tests migrados a las variantes paginadas.
- Quita el @ExceptionHandler(IOException) inalcanzable.
- Quita el @Cacheable redundante de getAllFederalEntities + su región.

Estructura:
- ZipCode es inmutable (@Builder, campos final, sin @Setter).
- Extrae carga/parseo a SepomexZipCodeLoader -> ZipCodeData y la paginación a PaginationSupport; ZipCodeService queda enfocado en consultas (935 -> ~430 líneas) y publica los índices como volatile.

Docs:
- CLAUDE.md sincronizado (Spring Boot 4.0.6, 66 tests, HashMap/TreeMap, regiones de caché reales, ZipCodeApi/CacheControlInterceptor).