### PR TITLE
feat: CI, frescura de datos, readiness/liveness y dedup de memoria

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# Cancela ejecuciones anteriores de la misma rama/PR cuando llega un nuevo push.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - name: Build and run tests
+        run: mvn -B --no-transfer-progress verify
+
+      - name: Publish test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: target/surefire-reports/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ High-performance REST API for querying Mexican postal codes (ZIP codes). Built w
 ```bash
 mvn clean package              # Build JAR
 mvn spring-boot:run            # Run with dev profile
-mvn test                       # Run all 66 tests (service + controller + rate-limit + health + context)
+mvn test                       # Run all 70 tests (service + controller + rate-limit + health + context)
 mvn spring-boot:run -Dspring-boot.run.profiles=prod  # Run with production profile
 ```
 
@@ -20,7 +20,7 @@ mvn spring-boot:run -Dspring-boot.run.profiles=prod  # Run with production profi
    - `TreeMap<String, ZipCode>` (`NavigableMap`) - O(log n) prefix search (autocomplete) via `subMap()`
    - `Map<String, Set<ZipCode>>` - Inverted index by normalized federal entity
    - `Map<String, Set<ZipCode>>` - Inverted index by normalized municipality
-3. **Pre-computation**: Statistics, federal entities list, and the municipalities-by-entity index are computed once at startup (immutable after load)
+3. **Pre-computation**: Statistics, federal entities list, and the municipalities-by-entity index are computed once at startup (immutable after load). A SHA-256 checksum of the source catalog is computed in the same read pass and exposed via `/zip-codes/stats` (`catalogChecksum`/`catalogSource`/`loadedAt`) for data-freshness visibility.
 4. **Caching**: 5 Spring-managed Caffeine cache regions (`zipcodes`, `federalEntitySearchPaged`, `municipalitySearchPaged`, `municipalitiesByEntity`, `advancedSearchPaged`) plus a manually-managed `partialPrefixCache` (Caffeine) inside `ZipCodeService` to sidestep Spring's self-invocation pitfall
 5. **Serving**: REST endpoints in `Controller.java` (contract in `ZipCodeApi` interface) with pagination, validation, and Swagger docs
 
@@ -32,6 +32,8 @@ mvn spring-boot:run -Dspring-boot.run.profiles=prod  # Run with production profi
 - **`TreeMap.subMap()`**: Prefix search uses sorted map range query instead of full scan
 - **Low-cardinality metrics**: Search metrics use type tags (direct/federal_entity/municipality/partial) instead of per-zipcode counters to avoid Prometheus series explosion
 - **Caffeine for rate limit buckets**: Auto-eviction after 5 min of inactivity prevents memory leaks vs unbounded ConcurrentHashMap
+- **Canonical String pool at load**: low-cardinality fields (federal entity ~32, municipality ~2500, settlement/zone types) are deduplicated during parsing so the ~145k `ZipCode` objects share single String instances, cutting heap footprint
+- **Liveness/Readiness probes**: Actuator health groups (`/actuator/health/liveness` and `/readiness`); the `zipCode` indicator feeds the readiness group so traffic is only routed once the catalog is loaded
 
 ### Project Structure
 ```

--- a/README.md
+++ b/README.md
@@ -244,9 +244,15 @@ curl "http://localhost:8080/zip-codes/advanced?federal_entity=jalisco&municipali
   "totalZipCodes": 31918,
   "totalFederalEntities": 32,
   "totalMunicipalities": 2337,
-  "totalSettlements": 157424
+  "totalSettlements": 157424,
+  "loadedAt": "2026-06-13T10:15:30",
+  "catalogChecksum": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  "catalogSource": "classpath:CPdescarga.txt"
 }
 ```
+
+The `catalogChecksum` (SHA-256 of the source catalog) and `loadedAt`/`catalogSource`
+let you verify which version of the SEPOMEX catalog the running instance is serving.
 
 ### Interactive Documentation
 
@@ -373,10 +379,15 @@ mvn test jacoco:report
 
 ### Test Coverage
 
-- **Total tests:** 33
-- **Unit tests:** 14 (ZipCodeServiceTest)
-- **Integration tests:** 18 (ControllerTest)
-- **Application test:** 1
+- **Total tests:** 70
+- **Service tests:** 25 (ZipCodeServiceTest)
+- **Controller/integration tests:** 34 (ControllerTest)
+- **Rate-limit tests:** 7 (RateLimitInterceptorTest)
+- **Health indicator tests:** 3 (ZipCodeHealthIndicatorTest)
+- **Application context test:** 1
+
+Tests run automatically on every push and pull request via GitHub Actions
+(`.github/workflows/ci.yml`).
 
 ## Performance
 

--- a/src/main/java/com/coderalexis/CodigoPostalApi/model/ZipCodeStats.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/model/ZipCodeStats.java
@@ -1,9 +1,12 @@
 package com.coderalexis.CodigoPostalApi.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Data
 @Builder
@@ -14,4 +17,17 @@ public class ZipCodeStats {
     private int totalFederalEntities;
     private int totalMunicipalities;
     private long totalSettlements;
+
+    /**
+     * Metadata de frescura del catálogo: cuándo se cargó en este proceso, un
+     * checksum SHA-256 del archivo fuente (identifica unívocamente la versión de
+     * los datos) y el origen desde el que se leyó. Permite saber si el catálogo
+     * está desactualizado sin redeployar a ciegas.
+     */
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime loadedAt;
+
+    private String catalogChecksum;
+
+    private String catalogSource;
 }

--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/SepomexZipCodeLoader.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/SepomexZipCodeLoader.java
@@ -18,9 +18,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -38,6 +42,10 @@ import java.util.regex.Pattern;
  * primero se acumulan los asentamientos de cada código postal en una estructura
  * temporal y luego se construye el objeto definitivo, evitando exponer estado
  * mutable.</p>
+ *
+ * <p>Durante la lectura se calcula, en una sola pasada, un checksum SHA-256 del
+ * archivo (frescura de datos) y se canonizan los Strings de baja cardinalidad
+ * (entidad, municipio, localidad, tipos) para reducir el footprint de memoria.</p>
  */
 @Slf4j
 @Component
@@ -68,21 +76,23 @@ public class SepomexZipCodeLoader {
     private int errorCount = 0;
 
     /**
-     * Carga el catálogo y devuelve las cuatro estructuras de índice ya construidas.
+     * Carga el catálogo y devuelve las cuatro estructuras de índice ya construidas,
+     * junto con la metadata de frescura (checksum y origen).
      *
-     * @return los índices, o {@code null} si no se pudo localizar ningún archivo.
+     * @return los índices + metadata, o {@code null} si no se pudo localizar ningún archivo.
      * @throws IOException si ocurre un error de lectura sobre un origen existente.
      */
     public ZipCodeData load() throws IOException {
-        try (InputStream stream = getInputStream()) {
-            if (stream == null) {
-                return null;
-            }
-            return parse(stream);
+        ResolvedSource resolved = resolveSource();
+        if (resolved == null) {
+            return null;
+        }
+        try (InputStream stream = resolved.stream()) {
+            return parse(stream, resolved.description());
         }
     }
 
-    private ZipCodeData parse(InputStream stream) throws IOException {
+    private ZipCodeData parse(InputStream stream, String source) throws IOException {
         long startTime = System.currentTimeMillis();
         errorCount = 0;
 
@@ -90,22 +100,29 @@ public class SepomexZipCodeLoader {
         Charset charset = detectCharset(bufferedStream);
         log.info("Encoding detectado: {}", charset.name());
 
-        // Estructura temporal mutable: acumula los asentamientos por código postal
-        // antes de materializar el ZipCode inmutable.
+        MessageDigest digest = newSha256();
+        // Se envuelve DESPUÉS de detectCharset (que hace mark/reset sobre los primeros
+        // bytes), de modo que cada byte del archivo se digiere exactamente una vez.
+        DigestInputStream digestStream = new DigestInputStream(bufferedStream, digest);
+
+        // Estructuras temporales mutables: acumulan asentamientos por CP y canonizan
+        // los Strings repetidos. Ambas se descartan al terminar el parseo.
         Map<String, Accumulator> accumulators = new HashMap<>();
+        Map<String, String> stringPool = new HashMap<>();
 
         try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(bufferedStream, charset))) {
+                new InputStreamReader(digestStream, charset))) {
 
             // Skip first two lines (metadata and header)
             reader.readLine();
             reader.readLine();
 
             long linesProcessed = reader.lines()
-                    .filter(line -> processLine(line, accumulators))
+                    .filter(line -> processLine(line, accumulators, stringPool))
                     .count();
 
-            ZipCodeData data = buildIndices(accumulators);
+            String checksum = HexFormat.of().formatHex(digest.digest());
+            ZipCodeData data = buildIndices(accumulators, checksum, source);
 
             long duration = System.currentTimeMillis() - startTime;
             log.info("Datos cargados exitosamente en {}ms", duration);
@@ -113,6 +130,7 @@ public class SepomexZipCodeLoader {
             log.info("  - Entidades federativas: {}", data.byNormalizedEntity().size());
             log.info("  - Municipios: {}", data.byNormalizedMunicipality().size());
             log.info("  - Lineas procesadas: {}", linesProcessed);
+            log.info("  - Origen: {} | checksum SHA-256: {}", source, checksum);
             if (errorCount > 0) {
                 log.warn("  - Lineas con errores: {}", errorCount);
             }
@@ -121,7 +139,7 @@ public class SepomexZipCodeLoader {
         }
     }
 
-    private ZipCodeData buildIndices(Map<String, Accumulator> accumulators) {
+    private ZipCodeData buildIndices(Map<String, Accumulator> accumulators, String checksum, String source) {
         Map<String, ZipCode> byCode = new HashMap<>(accumulators.size() * 2);
         NavigableMap<String, ZipCode> sorted = new TreeMap<>();
         Map<String, Set<ZipCode>> byNormalizedEntity = new HashMap<>();
@@ -140,18 +158,18 @@ public class SepomexZipCodeLoader {
                     .add(zipCode);
         }
 
-        return new ZipCodeData(byCode, sorted, byNormalizedEntity, byNormalizedMunicipality);
+        return new ZipCodeData(byCode, sorted, byNormalizedEntity, byNormalizedMunicipality, checksum, source);
     }
 
     /**
-     * Resuelve el InputStream del catálogo SEPOMEX.
+     * Resuelve el origen del catálogo SEPOMEX (stream + descripción legible).
      *
      * <p>Fix #20: si el usuario configura un path explícito (vía
      * {@code zipcode.file.path}) y éste no existe, fallamos rápido en vez de
      * caer silenciosamente al recurso interno, que enmascaraba problemas de
      * despliegue (config incorrecta sin error visible).</p>
      */
-    private InputStream getInputStream() throws IOException {
+    private ResolvedSource resolveSource() throws IOException {
         boolean userConfiguredPath = filePath != null && !filePath.isBlank();
 
         if (userConfiguredPath && filePath.startsWith("classpath:")) {
@@ -159,7 +177,7 @@ public class SepomexZipCodeLoader {
             ClassPathResource resource = new ClassPathResource(resourcePath);
             if (resource.exists()) {
                 log.info("Cargando codigos postales desde classpath: {}", resourcePath);
-                return resource.getInputStream();
+                return new ResolvedSource(resource.getInputStream(), "classpath:" + resourcePath);
             }
             throw new IOException(
                 "Recurso configurado en 'zipcode.file.path' no encontrado en classpath: " + resourcePath);
@@ -169,7 +187,7 @@ public class SepomexZipCodeLoader {
             Path path = Paths.get(filePath);
             if (Files.exists(path)) {
                 log.info("Cargando codigos postales desde {}", filePath);
-                return Files.newInputStream(path);
+                return new ResolvedSource(Files.newInputStream(path), path.toString());
             }
             throw new IOException(
                 "Archivo configurado en 'zipcode.file.path' no encontrado: " + filePath);
@@ -178,7 +196,7 @@ public class SepomexZipCodeLoader {
         ClassPathResource resource = new ClassPathResource(RESOURCE_FILE);
         if (resource.exists()) {
             log.info("Cargando codigos postales desde recurso interno {}", RESOURCE_FILE);
-            return resource.getInputStream();
+            return new ResolvedSource(resource.getInputStream(), "classpath:" + RESOURCE_FILE);
         }
 
         return null;
@@ -223,7 +241,7 @@ public class SepomexZipCodeLoader {
         return StandardCharsets.ISO_8859_1;
     }
 
-    private boolean processLine(String line, Map<String, Accumulator> accumulators) {
+    private boolean processLine(String line, Map<String, Accumulator> accumulators, Map<String, String> pool) {
         try {
             String[] words = PIPE_PATTERN.split(line);
 
@@ -251,14 +269,15 @@ public class SepomexZipCodeLoader {
             String municipality = words[COL_MUNICIPALITY].trim();
 
             // El primer registro de un código postal fija entidad/municipio/localidad;
-            // los siguientes sólo añaden asentamientos.
+            // los siguientes sólo añaden asentamientos. Los Strings de baja cardinalidad
+            // se canonizan (#4) para que las ~145k entradas compartan las mismas instancias.
             Accumulator acc = accumulators.computeIfAbsent(zipCodeKey, k -> new Accumulator(
                     k,
-                    words[COL_LOCALITY].trim(),
-                    federalEntity,
-                    municipality,
-                    Util.normalizeString(federalEntity),
-                    Util.normalizeString(municipality)));
+                    canonical(words[COL_LOCALITY].trim(), pool),
+                    canonical(federalEntity, pool),
+                    canonical(municipality, pool),
+                    canonical(Util.normalizeString(federalEntity), pool),
+                    canonical(Util.normalizeString(municipality), pool)));
 
             String settlementName = words[COL_SETTLEMENT_NAME].trim();
             String settlementTypeVal = words[COL_SETTLEMENT_TYPE].trim();
@@ -266,13 +285,15 @@ public class SepomexZipCodeLoader {
                 words[COL_ZONE_TYPE_INDEX].trim() : "";
 
             // Fix #18: Settlements es un record inmutable con los campos normalizados precomputados.
+            // El nombre del asentamiento es de alta cardinalidad y no se canoniza; el tipo de
+            // asentamiento y el tipo de zona sí (apenas unas decenas de valores distintos).
             acc.settlements.add(new Settlements(
                     settlementName,
-                    zoneTypeVal,
-                    settlementTypeVal,
+                    canonical(zoneTypeVal, pool),
+                    canonical(settlementTypeVal, pool),
                     Util.normalizeString(settlementName),
-                    Util.normalizeString(settlementTypeVal),
-                    Util.normalizeString(zoneTypeVal)));
+                    canonical(Util.normalizeString(settlementTypeVal), pool),
+                    canonical(Util.normalizeString(zoneTypeVal), pool)));
 
             return true;
 
@@ -281,6 +302,26 @@ public class SepomexZipCodeLoader {
                 line.substring(0, Math.min(100, line.length())));
             log.debug("Detalle del error:", e);
             return false;
+        }
+    }
+
+    /**
+     * Devuelve la instancia canónica del String dado, de modo que valores
+     * repetidos (entidad, municipio, tipos) compartan un único objeto en memoria.
+     */
+    private static String canonical(String value, Map<String, String> pool) {
+        if (value == null) {
+            return null;
+        }
+        return pool.computeIfAbsent(value, k -> k);
+    }
+
+    private MessageDigest newSha256() throws IOException {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 es obligatorio en toda JVM; si faltara, el entorno está roto.
+            throw new IOException("Algoritmo SHA-256 no disponible en la JVM", e);
         }
     }
 
@@ -295,6 +336,13 @@ public class SepomexZipCodeLoader {
 
     private boolean isValidZipCode(String zipCode) {
         return zipCode != null && ZIP_CODE_PATTERN.matcher(zipCode).matches();
+    }
+
+    /**
+     * Origen resuelto del catálogo: el stream a leer y una descripción legible
+     * (classpath:... o ruta de archivo) para exponer como metadata de frescura.
+     */
+    private record ResolvedSource(InputStream stream, String description) {
     }
 
     /**

--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeData.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeData.java
@@ -18,10 +18,16 @@ import java.util.Set;
  *   <li>{@code byNormalizedEntity} - índice invertido por entidad federativa normalizada</li>
  *   <li>{@code byNormalizedMunicipality} - índice invertido por municipio normalizado</li>
  * </ul>
+ *
+ * <p>Incluye además metadata de frescura: {@code checksum} (SHA-256 del archivo
+ * fuente) y {@code source} (origen legible), para exponer qué versión del
+ * catálogo está sirviendo la API.</p>
  */
 public record ZipCodeData(
         Map<String, ZipCode> byCode,
         NavigableMap<String, ZipCode> sorted,
         Map<String, Set<ZipCode>> byNormalizedEntity,
-        Map<String, Set<ZipCode>> byNormalizedMunicipality) {
+        Map<String, Set<ZipCode>> byNormalizedMunicipality,
+        String checksum,
+        String source) {
 }

--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
@@ -19,6 +19,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -135,7 +136,7 @@ public class ZipCodeService {
         this.zipCodesByNormalizedEntity = data.byNormalizedEntity();
         this.zipCodesByNormalizedMunicipality = data.byNormalizedMunicipality();
 
-        buildPreComputedData();
+        buildPreComputedData(data.checksum(), data.source(), LocalDateTime.now());
 
         // Fix #2: marcamos dataLoaded sólo DESPUÉS de que las estructuras
         // precomputadas (cachedStats, cachedFederalEntities,
@@ -143,7 +144,7 @@ public class ZipCodeService {
         dataLoaded = true;
     }
 
-    private void buildPreComputedData() {
+    private void buildPreComputedData(String catalogChecksum, String catalogSource, LocalDateTime loadedAt) {
         // Single pass (#10): durante esta pasada acumulamos totalSettlements y la
         // lista de FederalEntity para evitar recorrer el mapa varias veces.
         long totalSettlements = 0L;
@@ -167,6 +168,9 @@ public class ZipCodeService {
                 .totalFederalEntities(zipCodesByNormalizedEntity.size())
                 .totalMunicipalities(zipCodesByNormalizedMunicipality.size())
                 .totalSettlements(totalSettlements)
+                .loadedAt(loadedAt)
+                .catalogChecksum(catalogChecksum)
+                .catalogSource(catalogSource)
                 .build();
 
         cachedFederalEntities = zipCodesByEntity.entrySet().stream()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,16 @@ management:
     health:
       show-details: when-authorized
       show-components: when-authorized
+      # Liveness/Readiness diferenciadas para orquestadores (Railway/k8s):
+      # - liveness: el proceso está vivo (no reiniciar por falta de datos).
+      # - readiness: el catálogo está cargado; hasta entonces no se enruta tráfico.
+      probes:
+        enabled: true
+      group:
+        liveness:
+          include: livenessState
+        readiness:
+          include: readinessState,zipCode
     prometheus:
       enabled: true
     info:

--- a/src/test/java/com/coderalexis/CodigoPostalApi/controller/ControllerTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/controller/ControllerTest.java
@@ -393,4 +393,23 @@ class ControllerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(header().doesNotExist("Cache-Control"));
     }
+
+    @Test
+    @DisplayName("GET /zip-codes/stats - Debe exponer metadata de frescura del catálogo")
+    void shouldExposeCatalogFreshnessInStats() throws Exception {
+        mockMvc.perform(get("/zip-codes/stats")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.catalogChecksum").exists())
+                .andExpect(jsonPath("$.catalogSource").exists())
+                .andExpect(jsonPath("$.loadedAt").exists());
+    }
+
+    @Test
+    @DisplayName("GET /actuator/health/readiness - Debe reportar UP con el catálogo cargado")
+    void shouldReportReadinessUp() throws Exception {
+        mockMvc.perform(get("/actuator/health/readiness"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
 }

--- a/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
@@ -300,4 +300,28 @@ class ZipCodeServiceTest {
         assertThrows(IllegalArgumentException.class, () -> zipCodeService.advancedSearch(request, 0, 0));
     }
 
+    @Test
+    @DisplayName("Debe exponer metadata de frescura del catálogo en las estadísticas")
+    void shouldExposeCatalogFreshnessMetadata() {
+        ZipCodeStats stats = zipCodeService.getStatistics();
+
+        assertNotNull(stats.getLoadedAt(), "Debe registrar cuándo se cargó el catálogo");
+        assertNotNull(stats.getCatalogChecksum(), "Debe exponer el checksum del catálogo");
+        assertTrue(stats.getCatalogChecksum().matches("[0-9a-f]{64}"),
+            "El checksum debe ser un SHA-256 en hexadecimal");
+        assertNotNull(stats.getCatalogSource(), "Debe exponer el origen del catálogo");
+        assertFalse(stats.getCatalogSource().isBlank());
+    }
+
+    @Test
+    @DisplayName("Debe canonizar los Strings repetidos de baja cardinalidad")
+    void shouldCanonicalizeRepeatedEntityStrings() {
+        PagedResponse<ZipCode> page = zipCodeService.searchByFederalEntity("Ciudad de México", 0, 2);
+        List<ZipCode> content = page.getContent();
+
+        assertTrue(content.size() >= 2, "Se necesitan al menos 2 CP de la misma entidad");
+        assertSame(content.get(0).getFederalEntity(), content.get(1).getFederalEntity(),
+            "Los CP de la misma entidad deben compartir la instancia canónica de federalEntity");
+    }
+
 }


### PR DESCRIPTION
## Resumen
Segunda ronda de mejoras sobre el trabajo de #13: observabilidad, operación cloud-native, CI y memoria. Suite **66 → 70 tests**, en verde.

## Cambios

### 1. CI en GitHub Actions
`.github/workflows/ci.yml`: corre `mvn verify` en cada push/PR (JDK 25 Temurin, caché de Maven, sube reportes de surefire). El repo no tenía CI.

### 2. Frescura / versión de datos
`GET /zip-codes/stats` ahora expone `catalogChecksum` (SHA-256 del archivo fuente, calculado en **una sola pasada** con `DigestInputStream`), `catalogSource` y `loadedAt`. Permite saber qué versión del catálogo SEPOMEX sirve la instancia sin redeployar a ciegas.

### 3. Readiness / Liveness
Health groups de Actuator: `/actuator/health/liveness` y `/actuator/health/readiness`. El indicator `zipCode` alimenta readiness, de modo que no se enruta tráfico hasta que el catálogo está cargado (complementa el fail-fast de #13).

### 4. Deduplicación de Strings (memoria)
Pool canónico durante la carga para los campos de baja cardinalidad (entidad ~32, municipio ~2500, localidad, tipos de asentamiento/zona). Las ~145k entradas comparten instancias, reduciendo el footprint de heap.

## Tests
- +4 tests: frescura (service + controller), endpoint readiness, canonicalización de Strings (`assertSame`).
- Total **70 tests**, todos en verde.

## Docs
- `CLAUDE.md` y `README.md` actualizados (conteo de tests, ejemplo de `/stats`, decisiones de diseño, nota de CI).

## Notas
- El CI se ejecuta por primera vez en este PR. Si el runner no encontrara Temurin 25 en `setup-java`, bastaría cambiar la distribución (`zulu`/`oracle`) — Temurin 25 ya es GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
