### PR TITLE
feat: cachés por término con negative caching, ETag por catálogo, CDS y robustez de API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,26 @@ jobs:
           path: target/surefire-reports/
           if-no-files-found: ignore
           retention-days: 7
+
+      - name: Publish coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Valida el Dockerfile completo (incluida la etapa de entrenamiento CDS,
+      # que arranca el contexto Spring y carga el catálogo). No publica imagen.
+      - name: Build image
+        run: docker build -t codigopostal-api:ci .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ High-performance REST API for querying Mexican postal codes (ZIP codes). Built w
 ```bash
 mvn clean package              # Build JAR
 mvn spring-boot:run            # Run with dev profile
-mvn test                       # Run all 70 tests (service + controller + rate-limit + health + context)
+mvn test                       # Run all 80 tests (service + controller + rate-limit + health + context)
+mvn verify                     # Tests + JaCoCo coverage report (target/site/jacoco/)
 mvn spring-boot:run -Dspring-boot.run.profiles=prod  # Run with production profile
 ```
 
@@ -18,22 +19,26 @@ mvn spring-boot:run -Dspring-boot.run.profiles=prod  # Run with production profi
 2. **Indexing**: Four index structures for different access patterns. They are populated sequentially during the single-threaded `@PostConstruct` and treated as **read-only after load**, so plain (non-concurrent) collections are used to avoid synchronization overhead on the hot read path:
    - `HashMap<String, ZipCode>` - O(1) direct lookup by zip code
    - `TreeMap<String, ZipCode>` (`NavigableMap`) - O(log n) prefix search (autocomplete) via `subMap()`
-   - `Map<String, Set<ZipCode>>` - Inverted index by normalized federal entity
-   - `Map<String, Set<ZipCode>>` - Inverted index by normalized municipality
-3. **Pre-computation**: Statistics, federal entities list, and the municipalities-by-entity index are computed once at startup (immutable after load). A SHA-256 checksum of the source catalog is computed in the same read pass and exposed via `/zip-codes/stats` (`catalogChecksum`/`catalogSource`/`loadedAt`) for data-freshness visibility.
-4. **Caching**: 5 Spring-managed Caffeine cache regions (`zipcodes`, `federalEntitySearchPaged`, `municipalitySearchPaged`, `municipalitiesByEntity`, `advancedSearchPaged`) plus a manually-managed `partialPrefixCache` (Caffeine) inside `ZipCodeService` to sidestep Spring's self-invocation pitfall
-5. **Serving**: REST endpoints in `Controller.java` (contract in `ZipCodeApi` interface) with pagination, validation, and Swagger docs
+   - `Map<String, List<ZipCode>>` - Inverted index by normalized federal entity; each bucket is an **immutable list pre-sorted by zip code at load time**
+   - `Map<String, List<ZipCode>>` - Inverted index by normalized municipality, same pre-sorted buckets
+   (buckets within one index are disjoint — each ZipCode has exactly one entity/municipality — so no Set dedup is needed and single-key matches are served with zero copies)
+3. **Pre-computation**: Statistics, federal entities list, and the municipalities-by-entity index are computed once at startup (immutable after load). A SHA-256 checksum of the source catalog is computed in the same read pass and exposed via `/zip-codes/stats` (`catalogChecksum`/`catalogSource`/`loadedAt`) for data-freshness visibility; it also feeds the global weak ETag (`EtagInterceptor`).
+4. **Caching**: 1 Spring-managed Caffeine region (`municipalitiesByEntity`) plus 4 manually-managed Caffeine caches inside `ZipCodeService` (`partialPrefixCache`, `entitySearchCache`, `municipalitySearchCache`, `advancedSearchCache`). Manual caches sidestep Spring's self-invocation pitfall, give per-key locking (no stampedes) and enable **negative caching**: search caches are keyed by normalized term/filter only (never page/size), store the **full sorted result list** (empty included), and pagination is a `subList` at read time; `ZipCodeNotFoundException` is still thrown per-request when the cached list is empty. All caches report metrics via `CaffeineCacheMetrics`.
+5. **Serving**: REST endpoints in `Controller.java` (contract in `ZipCodeApi` interface) with pagination, validation, and Swagger docs. GETs under `/zip-codes/**` carry a catalog-versioned weak ETag; `If-None-Match` hits return 304 from `preHandle` without running the handler.
 
 ### Key Design Decisions
 - **No database**: All data in memory (~200MB RAM) for sub-millisecond lookups
 - **Pre-computed normalized fields**: `ZipCode` stores `normalizedFederalEntity` and `normalizedMunicipality` (computed at load time) to avoid NFD normalization in hot search paths
-- **`@EqualsAndHashCode(of = "zipCode")`**: ZipCode identity is based solely on the zip code string, not the settlements list. This is critical for correctness in the inverted index Sets (each ZipCode's `settlements` list is replaced with an immutable `List.copyOf(...)` after load, and `Settlements` itself is an immutable record)
+- **`@EqualsAndHashCode(of = "zipCode")`**: ZipCode identity is based solely on the zip code string, not the settlements list (each ZipCode's `settlements` list is replaced with an immutable `List.copyOf(...)` after load, and `Settlements` itself is an immutable record)
+- **Term-keyed search caches (manual Caffeine)**: entity/municipality/advanced caches store the full sorted result list per normalized term — including empty lists (negative caching) — and never include page/size in the key. Chosen over `@Cacheable` deliberately: per-key locking, no self-invocation trap, and the 404 can still be thrown per-request after a cache hit on an empty list. Don't convert them back to `@Cacheable`.
 - **Sequential streams for small indices**: Federal entity index has ~32 entries, municipality ~2500. `parallelStream()` overhead exceeds benefit at these sizes
 - **`TreeMap.subMap()`**: Prefix search uses sorted map range query instead of full scan
 - **Low-cardinality metrics**: Search metrics use type tags (direct/federal_entity/municipality/partial) instead of per-zipcode counters to avoid Prometheus series explosion
-- **Caffeine for rate limit buckets**: Auto-eviction after 5 min of inactivity prevents memory leaks vs unbounded ConcurrentHashMap
-- **Canonical String pool at load**: low-cardinality fields (federal entity ~32, municipality ~2500, settlement/zone types) are deduplicated during parsing so the ~145k `ZipCode` objects share single String instances, cutting heap footprint
+- **Caffeine for rate limit buckets**: Auto-eviction after 5 min of inactivity prevents memory leaks vs unbounded ConcurrentHashMap. `X-RateLimit-Limit` = sustained rate, `X-RateLimit-Burst` = real bucket capacity; unset `burst-capacity` defaults to `requests-per-minute`
+- **Canonical String pool at load**: low-cardinality fields (federal entity ~32, municipality ~2500, settlement/zone types) are deduplicated during parsing so the ~145k `ZipCode` objects share single String instances, cutting heap footprint; their normalization is memoized (once per distinct value, not per line)
+- **Catalog-versioned ETag**: single process-wide weak ETag (`W/"<checksum16>-<version>"`) valid for every `/zip-codes/**` URL because responses are pure functions of (catalog, URL); 304s short-circuit in `preHandle` (no search, no serialization)
 - **Liveness/Readiness probes**: Actuator health groups (`/actuator/health/liveness` and `/readiness`); the `zipCode` indicator feeds the readiness group so traffic is only routed once the catalog is loaded
+- **Docker CDS training run**: the image boots the Spring context at build time (`spring.context.exit=onRefresh`) to generate a CDS archive; GC flags must match between training and runtime. Spring AOT was evaluated and rejected (it would freeze profile/property conditions at build time; this app switches between 5 runtime profiles)
 
 ### Project Structure
 ```
@@ -65,9 +70,12 @@ src/main/java/com/coderalexis/CodigoPostalApi/
 ## Performance Notes
 - Direct zip code lookup: O(1) HashMap (no cache: Map access is already O(1))
 - Partial/prefix search: O(log n + k) via TreeMap (NavigableMap) `subMap()`, results cached per-prefix in `partialPrefixCache`
-- Federal entity/municipality search: O(m) where m = matching index entries (not full scan)
-- Advanced search: Uses inverted indices as starting point, reduces candidate set before filtering
+- Federal entity/municipality search: O(index keys) scan only on cache miss; buckets are pre-sorted at load so no per-request sorting; cache hit + pagination = O(page) `subList`
+- Advanced search: Uses inverted indices as starting point; the full filtered list is computed once per filter combination and cached (worst case — settlement-only filter scanning ~145k entries — pays that cost once)
+- Negative caching: not-found terms/filters are cached as empty lists; repeated 404 queries never re-scan indices
 - Statistics & federal entities: Pre-computed at startup, O(1) retrieval
+- Conditional requests: catalog-versioned ETag → `304 Not Modified` before handler execution
 - HTTP/2 enabled for connection multiplexing
 - Gzip compression for responses > 1KB
-- Cache warmup on startup for common queries (parallel)
+- Cache warmup on startup for common queries (parallel); term-keyed caches mean a warmed term covers all its pages
+- Docker image ships a CDS archive generated at build time (1-3s faster cold start)

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,26 +20,54 @@ RUN ./mvnw package -DskipTests -B
 FROM eclipse-temurin:25-jre-alpine
 WORKDIR /app
 
-# Crear usuario no-root para seguridad
-RUN addgroup -S spring && adduser -S spring -G spring
+# Crear usuario no-root para seguridad. El directorio de logs se crea aquí porque
+# el perfil prod escribe a /var/log/codigopostal-api y el usuario spring no puede
+# crearlo en runtime (Logback fallaba con FileNotFoundException en cada arranque).
+RUN addgroup -S spring && adduser -S spring -G spring && \
+    mkdir -p /var/log/codigopostal-api && \
+    chown -R spring:spring /var/log/codigopostal-api
+
+# Flags de GC/heap compartidos entre el training run y el runtime: los archives
+# CDS son sensibles a los flags de la JVM y deben coincidir.
+# - UseCompactObjectHeaders: reduce headers de 12 a 8 bytes (ahorra ~20% heap)
+# - UseZGC: GC de baja latencia (generacional por defecto desde JDK 23; el flag
+#   ZGenerational fue eliminado y aborta el arranque en JDK 25)
+# - UseContainerSupport es default desde JDK 10, no hace falta pasarlo.
+ENV JVM_GC_OPTS="-XX:MaxRAMPercentage=70.0 -XX:+UseZGC -XX:+UseCompactObjectHeaders"
+
+# Extraer el JAR (el layout expandido arranca más rápido que el fat JAR) y
+# generar el archive CDS con un training run: arranca el contexto Spring
+# completo (incluida la carga del catálogo, lo que de paso valida el archivo en
+# build time) y sale limpiamente al terminar el refresh.
+COPY --from=build /workspace/target/*.jar app.jar
+RUN java -Djarmode=tools -jar app.jar extract --destination /app/application && \
+    rm app.jar && \
+    java $JVM_GC_OPTS \
+      -XX:ArchiveClassesAtExit=/app/application/app.jsa \
+      -Dspring.context.exit=onRefresh \
+      -Dcache.warmup.enabled=false \
+      -jar /app/application/app.jar
+
 USER spring:spring
 
-# Copiar JAR desde etapa de build
-COPY --from=build /workspace/target/*.jar app.jar
-
-# Configuración de JVM optimizada para Java 25
-# - UseCompactObjectHeaders: Reduce headers de 12 a 8 bytes (ahorra ~20% heap)
-# - UseZGC: GC de baja latencia optimizado en Java 25
-# - ZGenerational: Habilita el modo generacional de ZGC
-ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=70.0 -XX:+UseZGC -XX:+ZGenerational -XX:+UseCompactObjectHeaders -Djava.security.egd=file:/dev/./urandom"
+# El runtime carga el archive CDS generado arriba (clases pre-parseadas: 1-3s
+# menos de arranque en frío).
+ENV JAVA_OPTS="-XX:SharedArchiveFile=/app/application/app.jsa -Djava.security.egd=file:/dev/./urandom"
 
 # Puerto dinámico (Railway usa $PORT, default 8080)
 ENV PORT=8080
 EXPOSE ${PORT}
 
+# Puerto donde vive el actuator. El perfil prod lo separa a 9090; railway/dev lo
+# dejan en $PORT. Se deja vacío por defecto (= usar $PORT) y el healthcheck cae
+# al 9090 si el primero no responde, para que la imagen quede sana con cualquier
+# perfil aunque el operador no configure nada.
+ENV MANAGEMENT_PORT=""
+
 # Health check (start-period aumentado para carga de datos)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:${PORT}/actuator/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider "http://localhost:${MANAGEMENT_PORT:-$PORT}/actuator/health" || \
+      wget --no-verbose --tries=1 --spider http://localhost:9090/actuator/health || exit 1
 
 # Usar shell form para expandir variables de entorno
-ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -Dserver.port=${PORT} -jar /app/app.jar"]
+ENTRYPOINT ["sh", "-c", "exec java $JVM_GC_OPTS $JAVA_OPTS -Dserver.port=${PORT} -jar /app/application/app.jar"]

--- a/README.md
+++ b/README.md
@@ -317,29 +317,58 @@ SPRING_PROFILES_ACTIVE=railway
 
 Rate limit buckets use Caffeine cache with automatic eviction after 5 minutes of inactivity, preventing memory leaks.
 
+If `burst-capacity` is not configured, the effective bucket capacity equals `requests-per-minute` (the bucket can hold as many tokens as the advertised sustained rate).
+
 ### Response Headers
 
 ```
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 87
-X-RateLimit-Retry-After-Seconds: 60
+X-RateLimit-Limit: 100                 # Sustained rate (tokens refilled per minute)
+X-RateLimit-Burst: 20                  # Real bucket capacity (upper bound of Remaining)
+X-RateLimit-Remaining: 17
+X-RateLimit-Retry-After-Seconds: 60    # Only on 429 responses
 ```
 
 ## Caching
 
 ### Multi-Level Cache Strategy
 
-| Cache Name | Capacity | TTL | Use Case |
-|------------|----------|-----|----------|
-| `zipcodes` | 10,000 | 1 hour | Individual zip code lookups |
-| `federalEntitySearch` | 100 | 15 min | State-based searches |
-| `municipalitySearch` | 200 | 15 min | Municipality searches |
-| `partialSearch` | 500 | 10 min | Autocomplete searches |
-| `federalEntities` | 1 | 1 hour | States list |
-| `municipalitiesByEntity` | 50 | 30 min | Municipalities by state |
-| `advancedSearch` | 100 | 10 min | Multi-filter searches |
+Search caches are managed directly with Caffeine inside `ZipCodeService` (avoids Spring's
+self-invocation trap, gives per-key locking against cache stampedes, and enables
+**negative caching**: terms with no results are cached too, so repeated not-found
+queries never re-scan the indices — the 404 is still raised on every request).
 
-Cache warmup runs in parallel at startup for common queries.
+Entity/municipality/advanced caches are keyed **by normalized term only** (not by page):
+they store the full sorted result list and pagination is a cheap `subList`, so browsing
+pages of the same term never re-computes or re-sorts anything.
+
+| Cache | Managed by | Capacity | TTL | Use Case |
+|------------|-----------|----------|-----|----------|
+| `partialPrefix` | Caffeine (service) | 500 terms | 10 min (write) | Autocomplete prefix searches |
+| `federalEntitySearch` | Caffeine (service) | 200 terms | 30 min (access) | Full sorted list per state term |
+| `municipalitySearch` | Caffeine (service) | 200 terms | 30 min (access) | Full sorted list per municipality term |
+| `advancedSearch` | Caffeine (service) | 500K refs (weight) | 15 min (access) | Full filtered list per filter combination |
+| `municipalitiesByEntity` | Spring `@Cacheable` | 50 | 30 min (write) | Municipality names by state |
+
+All caches (manual and Spring-managed) are wired to Micrometer via `CaffeineCacheMetrics`,
+so hit ratios and evictions are visible in Prometheus (`cache_gets_total{cache="..."}`).
+
+Cache warmup runs in parallel at startup for common queries; since search caches are
+keyed by term, warming a term benefits every page and page size of that term.
+
+### HTTP Caching (ETag / 304)
+
+Every `GET /zip-codes/**` response carries a weak `ETag` derived from the catalog's
+SHA-256 checksum plus the app version. Clients (and CDNs) can revalidate with
+`If-None-Match`: a match short-circuits **before** the handler runs and returns
+`304 Not Modified` with no body — no search, no JSON serialization. The validator only
+changes when the catalog file or the application version changes.
+
+```bash
+curl -si http://localhost:8080/zip-codes/01000 | grep ETag
+# ETag: W/"3f6c2a9b8d41e07a-3.0.0-SNAPSHOT"
+curl -si -H 'If-None-Match: W/"3f6c2a9b8d41e07a-3.0.0-SNAPSHOT"' http://localhost:8080/zip-codes/01000
+# HTTP/1.1 304 Not Modified
+```
 
 ## Monitoring and Metrics
 
@@ -379,15 +408,19 @@ mvn test jacoco:report
 
 ### Test Coverage
 
-- **Total tests:** 70
-- **Service tests:** 25 (ZipCodeServiceTest)
-- **Controller/integration tests:** 34 (ControllerTest)
-- **Rate-limit tests:** 7 (RateLimitInterceptorTest)
+- **Total tests:** 80
+- **Service tests:** 29 (ZipCodeServiceTest — includes negative caching, page consistency and cache-hit metrics)
+- **Controller/integration tests:** 39 (ControllerTest — includes 400/405 error mapping and ETag/304)
+- **Rate-limit tests:** 8 (RateLimitInterceptorTest)
 - **Health indicator tests:** 3 (ZipCodeHealthIndicatorTest)
 - **Application context test:** 1
 
+The JaCoCo HTML report is generated at `target/site/jacoco/index.html` (also produced by
+`mvn verify` and uploaded as a CI artifact).
+
 Tests run automatically on every push and pull request via GitHub Actions
-(`.github/workflows/ci.yml`).
+(`.github/workflows/ci.yml`), which also builds the Docker image (including the CDS
+training run) to catch Dockerfile regressions.
 
 ## Performance
 
@@ -395,19 +428,27 @@ Tests run automatically on every push and pull request via GitHub Actions
 
 | Operation | Complexity | Data Structure |
 |-----------|-----------|----------------|
-| Direct zip code lookup | O(1) | ConcurrentHashMap |
-| Prefix/autocomplete search | O(log n + k) | ConcurrentSkipListMap.subMap() |
-| Federal entity search | O(m) | Inverted index (32 entries) |
-| Municipality search | O(m) | Inverted index (~2500 entries) |
-| Advanced search | O(candidates) | Inverted index as starting point |
+| Direct zip code lookup | O(1) | HashMap |
+| Prefix/autocomplete search | O(log n + k) | TreeMap (NavigableMap) `subMap()` |
+| Federal entity search | O(m) on miss, O(page) on hit | Inverted index (32 pre-sorted buckets) + term-keyed cache |
+| Municipality search | O(m) on miss, O(page) on hit | Inverted index (~2500 pre-sorted buckets) + term-keyed cache |
+| Advanced search | O(candidates) once per filter combo | Inverted index as starting point + term-keyed cache |
 | Statistics | O(1) | Pre-computed at startup |
 | Federal entities list | O(1) | Pre-computed at startup |
 
 ### Optimizations Applied
 
+- **Pre-sorted inverted index buckets**: each entity/municipality bucket is sorted once at
+  load time and frozen as an immutable list — paginated searches never re-sort per request
+- **Term-keyed search caches with negative caching**: full sorted result lists cached per
+  normalized term (empty results included); pagination is a `subList`, cold keys are
+  computed once thanks to Caffeine per-key locking (no cache stampede)
 - **Pre-computed normalized fields**: NFD normalization done at load time, not at query time
-- **ConcurrentSkipListMap**: Prefix search uses `subMap()` range query instead of O(n) full scan
-- **Inverted indices for advanced search**: Reduces candidate set from ~32K to ~2K before filtering
+- **Memoized normalization in the loader**: low-cardinality settlement/zone types are
+  normalized once per distinct value instead of once per line (~1.5M redundant NFD passes removed)
+- **TreeMap (NavigableMap)**: Prefix search uses `subMap()` range query instead of O(n) full scan
+- **Inverted indices for advanced search**: Reduces candidate set before filtering
+- **Canonical String pool at load**: repeated low-cardinality strings share single instances
 - **Sequential streams for small collections**: Avoids ForkJoinPool overhead on indices with <100 entries
 - **Pre-compiled regex Pattern**: `PIPE_PATTERN` compiled once for file parsing
 - **Pre-computed statistics**: Stats and federal entities calculated once at startup
@@ -416,12 +457,15 @@ Tests run automatically on every push and pull request via GitHub Actions
 - **Parallel cache warmup**: CompletableFuture for concurrent cache preloading
 - **HTTP/2**: Enabled for connection multiplexing
 - **Response compression**: Gzip for responses > 1KB
+- **Catalog-versioned ETag**: conditional requests return 304 before running the handler
 
 ### Java 25 Optimizations
 
 - **Compact Object Headers**: Reduces object header from 12 to 8 bytes (~20% heap reduction)
-- **ZGC Generational**: Low-latency garbage collector
+- **ZGC**: Low-latency garbage collector (generational by default since JDK 23)
 - **Virtual Threads**: Enabled for high concurrency
+- **CDS archive baked into the Docker image**: classes pre-parsed during a build-time
+  training run cut 1-3s of cold-start time
 
 ## Docker Deployment
 
@@ -440,15 +484,28 @@ docker run -p 8080:8080 \
 ### Dockerfile Features
 
 - Multi-stage build (JDK 25 for build, JRE 25 Alpine for runtime)
+- Extracted JAR layout (`jarmode=tools extract`) — faster startup than the fat JAR
+- **CDS training run at build time**: the Spring context boots once during `docker build`
+  (`-Dspring.context.exit=onRefresh`), generating a class-data-sharing archive loaded at
+  runtime via `-XX:SharedArchiveFile` (measured ~1.1s faster startup: 3.4s vs 4.8s average;
+  also validates the catalog file at build time). Note: with ZGC only the class portion of
+  the archive is used — archived heap objects are not supported by ZGC and the JVM logs a
+  harmless `Cannot use CDS heap data` notice at startup.
 - Non-root user for security
-- Integrated health check
+- **Profile-aware health check**: the `prod` profile moves actuator to port 9090, so the
+  healthcheck probes `${MANAGEMENT_PORT:-$PORT}` and falls back to 9090 — the container
+  reports healthy on every profile without extra configuration
+- Log directory `/var/log/codigopostal-api` is pre-created and owned by the `spring` user
+  (the `prod` profile writes there; without it Logback failed on every container start)
 - JVM optimizations for containers:
   ```
   -XX:+UseCompactObjectHeaders
   -XX:+UseZGC
-  -XX:+ZGenerational
   -XX:MaxRAMPercentage=70.0
+  -XX:SharedArchiveFile=/app/application/app.jsa
   ```
+  (`-XX:+ZGenerational` was removed: generational ZGC is the default since JDK 23 and the
+  flag no longer exists on JDK 25; `-XX:+UseContainerSupport` is the default since JDK 10)
 
 ## Railway Deployment
 
@@ -528,6 +585,40 @@ Postal codes data sourced from:
 [Download latest data](https://www.correosdemexico.gob.mx/SSLServicios/ConsultaCP/CodigoPostal_Exportar.aspx)
 
 ## Version History
+
+### v3.2.0 (2026-07-21)
+- **Hot-path performance**:
+  - Inverted index buckets pre-sorted at load time (no per-request re-sorting)
+  - Search caches redesigned: keyed by normalized term only (page/size no longer churn
+    cache keys), storing the full sorted list; pagination is a cheap `subList`
+  - Negative caching: not-found terms are cached (repeated 404s no longer re-scan indices)
+  - Per-key locking via Caffeine `get(key, fn)` eliminates cache stampedes on cold keys
+  - Loader memoizes normalization of low-cardinality settlement/zone types (~1.5M
+    redundant NFD passes removed at startup)
+  - Removed dead `zipcodes` cache region; all manual caches now report metrics to Prometheus
+- **API robustness**:
+  - Missing required query param now returns 400 (was 500); type mismatches return 400;
+    unsupported methods return 405 with `Allow` header
+  - `ErrorResponse` semantics unified: `message` describes the error, `path` is always the request URI
+  - New `X-RateLimit-Burst` header; unset `burst-capacity` now defaults to
+    `requests-per-minute` instead of a silent cap of 20
+- **HTTP caching & security**:
+  - Weak ETag derived from the catalog SHA-256 + app version on all `/zip-codes/**` GETs;
+    `If-None-Match` returns `304` before executing the handler
+  - Railway profile no longer exposes `/actuator/prometheus` publicly by default
+    (opt back in with `ACTUATOR_EXPOSURE`)
+- **Build & deploy**:
+  - JaCoCo coverage report wired into the build (`mvn verify` → `target/site/jacoco/`)
+  - CI uploads coverage and builds the Docker image on every push/PR
+  - Dockerfile: extracted JAR layout + build-time CDS training run (measured ~1.1s faster
+    startup); removed obsolete `-XX:+ZGenerational`/`-XX:+UseContainerSupport` flags
+  - `spring-boot-maven-plugin` now generates build-info (app version feeds the ETag)
+- **Container fixes** (found while verifying the image):
+  - Docker healthcheck was permanently failing under the `prod` profile (actuator listens
+    on 9090 there, the check probed `$PORT`) — orchestrators would have restart-looped the
+    container; now probes `MANAGEMENT_PORT` with a 9090 fallback
+  - Pre-created `/var/log/codigopostal-api` owned by the `spring` user, fixing the Logback
+    `FileNotFoundException` logged on every `prod` container start
 
 ### v3.1.0 (2026-02-07)
 - **Performance optimizations**:

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 		<java.version>25</java.version>
 		<springdoc.version>3.0.1</springdoc.version>
 		<bucket4j.version>8.10.1</bucket4j.version>
+		<jacoco.version>0.8.13</jacoco.version>
 	</properties>
 	<dependencies>
 		<!-- Spring Boot Core Starters -->
@@ -114,6 +115,35 @@
 						</exclude>
 					</excludes>
 				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<!-- Genera META-INF/build-info.properties: BuildProperties queda
+							     disponible y el EtagInterceptor incluye la versión real de la
+							     app en el ETag (cambia el validador entre despliegues). -->
+							<goal>build-info</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,10 @@ builder = "dockerfile"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "java $JAVA_OPTS -jar /app/app.jar --spring.profiles.active=railway"
+# Debe coincidir con el layout del Dockerfile (jar extraído en /app/application) e
+# incluir $JVM_GC_OPTS: el archive CDS se genera con esos flags y la JVM lo rechaza
+# si el runtime arranca con flags de GC distintos.
+startCommand = "java $JVM_GC_OPTS $JAVA_OPTS -jar /app/application/app.jar --spring.profiles.active=railway"
 healthcheckPath = "/actuator/health"
 healthcheckTimeout = 60
 restartPolicyType = "on_failure"

--- a/src/main/java/com/coderalexis/CodigoPostalApi/config/CacheConfiguration.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/config/CacheConfiguration.java
@@ -24,54 +24,22 @@ public class CacheConfiguration {
     @Bean
     public CacheManager cacheManager() {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager(
-                "zipcodes",
-                "federalEntitySearchPaged",
-                "municipalitySearchPaged",
-                "municipalitiesByEntity",
-                "advancedSearchPaged"
+                "municipalitiesByEntity"
         );
 
-        // Direct zip code lookup: O(1) in-memory Map access, no cache benefit.
-        // Kept for backward compatibility with @Cacheable annotations.
-        registerCache(cacheManager, "zipcodes",
-                Caffeine.newBuilder()
-                        .maximumSize(10_000)
-                        .expireAfterAccess(1, TimeUnit.HOURS)
-                        .recordStats()
-                        .build());
-
-        // Federal entity search (paginated): results can be large (full ZipCode objects with settlements).
-        registerCache(cacheManager, "federalEntitySearchPaged",
-                Caffeine.newBuilder()
-                        .maximumSize(100)
-                        .expireAfterWrite(5, TimeUnit.MINUTES)
-                        .recordStats()
-                        .build());
-
-        registerCache(cacheManager, "municipalitySearchPaged",
-                Caffeine.newBuilder()
-                        .maximumSize(100)
-                        .expireAfterWrite(5, TimeUnit.MINUTES)
-                        .recordStats()
-                        .build());
-
-        // NOTA: la cache de búsqueda parcial (autocompletado) se gestiona directamente
-        // con Caffeine en ZipCodeService para evitar la trampa de self-invocation de
-        // Spring Cache.
+        // NOTA: las cachés de búsqueda (por prefijo, entidad, municipio y avanzada)
+        // se gestionan directamente con Caffeine dentro de ZipCodeService: evita la
+        // trampa de self-invocation de Spring Cache, permite negative caching
+        // (cachear listas vacías y aun así lanzar la excepción 404 por request) y
+        // da bloqueo por clave contra estampidas. Sus métricas se registran allí
+        // con CaffeineCacheMetrics, igual que aquí.
         // NOTA: getAllFederalEntities() ya NO se cachea (devuelve un campo inmutable
-        // en memoria), por eso no se registra la región "federalEntities".
+        // en memoria) y el lookup directo por CP tampoco (Map.get ya es O(1)).
 
         registerCache(cacheManager, "municipalitiesByEntity",
                 Caffeine.newBuilder()
                         .maximumSize(50)
                         .expireAfterWrite(30, TimeUnit.MINUTES)
-                        .recordStats()
-                        .build());
-
-        registerCache(cacheManager, "advancedSearchPaged",
-                Caffeine.newBuilder()
-                        .maximumSize(100)
-                        .expireAfterWrite(5, TimeUnit.MINUTES)
                         .recordStats()
                         .build());
 

--- a/src/main/java/com/coderalexis/CodigoPostalApi/config/CacheControlInterceptor.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/config/CacheControlInterceptor.java
@@ -2,9 +2,16 @@ package com.coderalexis.CodigoPostalApi.config;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.CacheControl;
-import org.springframework.stereotype.Component;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,11 +25,23 @@ import java.util.regex.Pattern;
  * conservadores y reflejan la estabilidad real del catálogo SEPOMEX (los
  * códigos postales cambian con muy baja frecuencia).
  *
+ * <p>El header se aplica en DOS puntos, porque ninguno cubre ambos casos:</p>
+ * <ul>
+ *   <li>{@link #beforeBodyWrite}: para respuestas con body ({@code @ResponseBody}).
+ *       Setearlo en {@code afterCompletion} llegaba tarde: el flush del generador
+ *       de Jackson compromete la respuesta (chunked) y el header se descartaba en
+ *       silencio en el servidor real — los tests MockMvc no lo detectan porque
+ *       {@code MockHttpServletResponse} nunca se compromete.</li>
+ *   <li>{@link #afterCompletion}: para respuestas sin body (p.ej. el 304 del
+ *       {@link EtagInterceptor}), donde la respuesta sigue sin comprometerse y el
+ *       body advice no se ejecuta.</li>
+ * </ul>
+ *
  * <p>No se aplica a respuestas de error (4xx/5xx) para evitar que un fallo
  * transitorio quede cacheado en intermediarios.</p>
  */
-@Component
-public class CacheControlInterceptor implements HandlerInterceptor {
+@ControllerAdvice
+public class CacheControlInterceptor implements HandlerInterceptor, ResponseBodyAdvice<Object> {
 
     private static final String CACHE_CONTROL_HEADER = "Cache-Control";
 
@@ -51,22 +70,46 @@ public class CacheControlInterceptor implements HandlerInterceptor {
     }
 
     @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response) {
+        if (response instanceof ServletServerHttpResponse servletResponse) {
+            applyCacheControl(servletResponse.getServletResponse(), request.getURI().getPath());
+        }
+        return body;
+    }
+
+    @Override
     public void afterCompletion(HttpServletRequest request,
                                 HttpServletResponse response,
                                 Object handler,
                                 Exception ex) {
-        if (ex != null || response.getStatus() >= 400) {
+        if (ex != null) {
+            return;
+        }
+        applyCacheControl(response, request.getRequestURI());
+    }
+
+    private void applyCacheControl(HttpServletResponse response, String uri) {
+        if (response.getStatus() >= 400) {
             // No cacheamos errores: un 404 transitorio no debería quedarse pegado en
             // un CDN.
             return;
         }
 
         if (response.containsHeader(CACHE_CONTROL_HEADER)) {
-            // Ya configurado por el controlador, no sobreescribir.
+            // Ya configurado por el controlador (o por la otra vía de esta clase).
             return;
         }
 
-        String uri = request.getRequestURI();
         for (Map.Entry<Pattern, String> rule : RULES.entrySet()) {
             if (rule.getKey().matcher(uri).matches()) {
                 response.setHeader(CACHE_CONTROL_HEADER, rule.getValue());

--- a/src/main/java/com/coderalexis/CodigoPostalApi/config/CacheWarmupRunner.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/config/CacheWarmupRunner.java
@@ -12,6 +12,11 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Precarga en paralelo las búsquedas más comunes al arrancar. Como las cachés
+ * de entidad/municipio se llavean sólo por término (no por página), calentar un
+ * término beneficia a TODAS las páginas y tamaños de página de ese término.
+ */
 @Configuration
 @Slf4j
 public class CacheWarmupRunner {

--- a/src/main/java/com/coderalexis/CodigoPostalApi/config/EtagInterceptor.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/config/EtagInterceptor.java
@@ -1,0 +1,96 @@
+package com.coderalexis.CodigoPostalApi.config;
+
+import com.coderalexis.CodigoPostalApi.model.ZipCodeStats;
+import com.coderalexis.CodigoPostalApi.service.ZipCodeService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * ETag global versionado por catálogo para los endpoints REST. Toda respuesta
+ * GET de {@code /zip-codes/**} es función pura de (versión del catálogo, URL),
+ * así que un único validador por proceso es correcto: los clientes HTTP
+ * comparan ETags por URL, y el valor sólo cambia cuando cambia el catálogo
+ * (checksum SHA-256 ya computado en el load) o la versión de la app (que puede
+ * alterar la serialización).
+ *
+ * <p>Se corta en {@code preHandle}: un {@code 304 Not Modified} no ejecuta la
+ * búsqueda ni la serialización Jackson, a diferencia de
+ * {@code ShallowEtagHeaderFilter}, que bufferiza el body completo y sólo ahorra
+ * ancho de banda. El header se setea también aquí (no en {@code postHandle},
+ * que para {@code @ResponseBody} llega tarde, con la respuesta ya escrita).</p>
+ *
+ * <p>ETag débil ({@code W/}) porque con compresión no se garantiza identidad
+ * byte a byte entre representaciones.</p>
+ */
+@Component
+public class EtagInterceptor implements HandlerInterceptor {
+
+    private static final int CHECKSUM_PREFIX_LENGTH = 16;
+    private static final String DEFAULT_VERSION = "0";
+
+    private final ZipCodeService zipCodeService;
+    private final String appVersion;
+    // Calculado perezosamente en el primer request (el catálogo ya está cargado:
+    // @PostConstruct corre antes de que el servidor acepte tráfico) y estable
+    // durante toda la vida del proceso.
+    private volatile String etag;
+
+    public EtagInterceptor(ZipCodeService zipCodeService, ObjectProvider<BuildProperties> buildProperties) {
+        this.zipCodeService = zipCodeService;
+        BuildProperties properties = buildProperties.getIfAvailable();
+        this.appVersion = properties != null ? properties.getVersion() : DEFAULT_VERSION;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String method = request.getMethod();
+        if (!"GET".equals(method) && !"HEAD".equals(method)) {
+            return true;
+        }
+
+        String currentEtag = currentEtag();
+        if (currentEtag == null) {
+            return true;
+        }
+
+        // Comparación débil por substring: el ETag termina en comilla, así que un
+        // validador no puede ser prefijo de otro. No se especial-casea "*" porque
+        // significa "si existe alguna representación" y eso no puede saberse sin
+        // ejecutar el handler (una URL que daría 404 no debe responder 304).
+        String ifNoneMatch = request.getHeader(HttpHeaders.IF_NONE_MATCH);
+        if (ifNoneMatch != null && ifNoneMatch.contains(currentEtag)) {
+            response.setHeader(HttpHeaders.ETAG, currentEtag);
+            response.setStatus(HttpStatus.NOT_MODIFIED.value());
+            return false;
+        }
+
+        response.setHeader(HttpHeaders.ETAG, currentEtag);
+        return true;
+    }
+
+    private String currentEtag() {
+        String cached = etag;
+        if (cached != null) {
+            return cached;
+        }
+
+        ZipCodeStats stats = zipCodeService.getStatistics();
+        if (stats == null || stats.getCatalogChecksum() == null) {
+            return null;
+        }
+
+        String checksum = stats.getCatalogChecksum();
+        String prefix = checksum.length() > CHECKSUM_PREFIX_LENGTH
+                ? checksum.substring(0, CHECKSUM_PREFIX_LENGTH)
+                : checksum;
+        cached = "W/\"" + prefix + "-" + appVersion + "\"";
+        etag = cached;
+        return cached;
+    }
+}

--- a/src/main/java/com/coderalexis/CodigoPostalApi/config/RateLimitInterceptor.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/config/RateLimitInterceptor.java
@@ -78,7 +78,11 @@ public class RateLimitInterceptor implements HandlerInterceptor {
 
         if (bucket.tryConsume(1)) {
             long availableTokens = bucket.getAvailableTokens();
+            // Limit = tasa sostenida (refill por minuto); Burst = capacidad real del
+            // bucket, que es la cota de Remaining. Sin el header Burst, un Remaining
+            // menor que Limit resultaba inexplicable para el cliente.
             response.setHeader("X-RateLimit-Limit", String.valueOf(rateLimitProperties.getRequestsPerMinute()));
+            response.setHeader("X-RateLimit-Burst", String.valueOf(rateLimitProperties.getEffectiveBurstCapacity()));
             response.setHeader("X-RateLimit-Remaining", String.valueOf(availableTokens));
             return true;
         }
@@ -98,6 +102,7 @@ public class RateLimitInterceptor implements HandlerInterceptor {
             throws java.io.IOException {
         response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
         response.setHeader("X-RateLimit-Limit", String.valueOf(rateLimitProperties.getRequestsPerMinute()));
+        response.setHeader("X-RateLimit-Burst", String.valueOf(rateLimitProperties.getEffectiveBurstCapacity()));
         response.setHeader("X-RateLimit-Remaining", "0");
         response.setHeader("X-RateLimit-Retry-After-Seconds", "60");
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
@@ -115,7 +120,7 @@ public class RateLimitInterceptor implements HandlerInterceptor {
 
     private Bucket createNewBucket() {
         Bandwidth limit = Bandwidth.builder()
-                .capacity(rateLimitProperties.getBurstCapacity())
+                .capacity(rateLimitProperties.getEffectiveBurstCapacity())
                 .refillGreedy(rateLimitProperties.getRequestsPerMinute(), Duration.ofMinutes(1))
                 .build();
 

--- a/src/main/java/com/coderalexis/CodigoPostalApi/config/RateLimitProperties.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/config/RateLimitProperties.java
@@ -32,13 +32,24 @@ public class RateLimitProperties {
     private boolean ipBased = true;
 
     /**
-     * Capacidad de ráfaga (burst capacity)
-     * Permite un pico temporal de peticiones
+     * Capacidad de ráfaga (burst capacity): permite un pico temporal de
+     * peticiones. {@code 0} (default) significa "no configurada": la capacidad
+     * efectiva pasa a ser {@code requestsPerMinute}. Antes el default silencioso
+     * era 20, con lo que un perfil que sólo configuraba requests-per-minute=1000
+     * anunciaba 1000/min pero el bucket nunca podía contener más de 20 tokens.
      */
-    private int burstCapacity = 20;
+    private int burstCapacity = 0;
 
     /**
      * Lista de IPs en whitelist (sin rate limiting)
      */
     private List<String> whitelist = new ArrayList<>();
+
+    /**
+     * Capacidad real del bucket: el burst configurado o, si no se configuró,
+     * la tasa sostenida por minuto.
+     */
+    public int getEffectiveBurstCapacity() {
+        return burstCapacity > 0 ? burstCapacity : requestsPerMinute;
+    }
 }

--- a/src/main/java/com/coderalexis/CodigoPostalApi/config/WebMvcConfiguration.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/config/WebMvcConfiguration.java
@@ -19,13 +19,16 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
     private final RateLimitInterceptor rateLimitInterceptor;
     private final RateLimitProperties rateLimitProperties;
     private final CacheControlInterceptor cacheControlInterceptor;
+    private final EtagInterceptor etagInterceptor;
 
     public WebMvcConfiguration(RateLimitInterceptor rateLimitInterceptor,
                               RateLimitProperties rateLimitProperties,
-                              CacheControlInterceptor cacheControlInterceptor) {
+                              CacheControlInterceptor cacheControlInterceptor,
+                              EtagInterceptor etagInterceptor) {
         this.rateLimitInterceptor = rateLimitInterceptor;
         this.rateLimitProperties = rateLimitProperties;
         this.cacheControlInterceptor = cacheControlInterceptor;
+        this.etagInterceptor = etagInterceptor;
     }
 
     @Override
@@ -46,7 +49,7 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
         if (rateLimitProperties.isEnabled()) {
             log.info("✓ Rate Limiting HABILITADO: {} req/min, Burst: {}",
                 rateLimitProperties.getRequestsPerMinute(),
-                rateLimitProperties.getBurstCapacity());
+                rateLimitProperties.getEffectiveBurstCapacity());
 
             registry.addInterceptor(rateLimitInterceptor)
                     .addPathPatterns("/zip-codes/**")  // Solo aplicar a endpoints de la API
@@ -58,5 +61,11 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
         } else {
             log.info("✗ Rate Limiting DESHABILITADO (perfil de desarrollo)");
         }
+
+        // ETag versionado por catálogo: registrado DESPUÉS del rate limit para que
+        // un 429 nunca se responda como 304 ni lleve ETag (si el rate limit corta,
+        // los preHandle posteriores no se ejecutan).
+        registry.addInterceptor(etagInterceptor)
+                .addPathPatterns("/zip-codes/**", "/zip-codes");
     }
 }

--- a/src/main/java/com/coderalexis/CodigoPostalApi/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/exceptions/GlobalExceptionHandler.java
@@ -1,11 +1,15 @@
 package com.coderalexis.CodigoPostalApi.exceptions;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import jakarta.validation.ConstraintViolationException;
@@ -30,6 +34,10 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
     }
 
+    // En todos los handlers, `message` describe el error y `path` contiene la URI
+    // del request (via request.getDescription); antes los handlers de validación
+    // invertían esa semántica poniendo la lista de errores en `path`.
+
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException ex, WebRequest request) {
         String errors = ex.getConstraintViolations()
@@ -39,8 +47,8 @@ public class GlobalExceptionHandler {
 
         ErrorResponse error = new ErrorResponse(
                 HttpStatus.BAD_REQUEST.value(),
-                "Errores de validación",
-                errors,
+                "Errores de validación: " + errors,
+                request.getDescription(false),
                 LocalDateTime.now()
         );
         log.warn("ConstraintViolationException: {}", errors);
@@ -54,15 +62,59 @@ public class GlobalExceptionHandler {
                           .stream()
                           .map(FieldError::getDefaultMessage)
                           .collect(Collectors.joining(", "));
-        
+
         ErrorResponse error = new ErrorResponse(
                 HttpStatus.BAD_REQUEST.value(),
-                "Errores de validación",
-                errors,
+                "Errores de validación: " + errors,
+                request.getDescription(false),
                 LocalDateTime.now()
         );
         log.warn("MethodArgumentNotValidException: {}", errors);
         return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException ex, WebRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Falta el parámetro requerido: " + ex.getParameterName(),
+                request.getDescription(false),
+                LocalDateTime.now()
+        );
+        log.warn("MissingServletRequestParameterException: {}", ex.getParameterName());
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException ex, WebRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Valor inválido para el parámetro '" + ex.getName() + "': " + ex.getValue(),
+                request.getDescription(false),
+                LocalDateTime.now()
+        );
+        log.warn("MethodArgumentTypeMismatchException: {}", ex.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException ex, WebRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.METHOD_NOT_ALLOWED.value(),
+                "Método " + ex.getMethod() + " no soportado para este recurso",
+                request.getDescription(false),
+                LocalDateTime.now()
+        );
+        log.warn("HttpRequestMethodNotSupportedException: {}", ex.getMethod());
+
+        HttpHeaders headers = new HttpHeaders();
+        if (ex.getSupportedHttpMethods() != null) {
+            headers.setAllow(ex.getSupportedHttpMethods());
+        }
+        return new ResponseEntity<>(error, headers, HttpStatus.METHOD_NOT_ALLOWED);
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
@@ -103,8 +155,8 @@ public class GlobalExceptionHandler {
     ) {
         ErrorResponse error = new ErrorResponse(
                 HttpStatus.BAD_REQUEST.value(),
-                "Argumento inválido",
-                ex.getMessage(),
+                "Argumento inválido: " + ex.getMessage(),
+                request.getDescription(false),
                 LocalDateTime.now()
         );
         log.warn("IllegalArgumentException: {}", ex.getMessage());

--- a/src/main/java/com/coderalexis/CodigoPostalApi/model/AdvancedSearchRequest.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/model/AdvancedSearchRequest.java
@@ -42,23 +42,31 @@ public class AdvancedSearchRequest {
 
     /**
      * Cache key estable basada exclusivamente en los filtros normalizados.
-     * Por diseño no incluye paginación ni formato porque ambos se aplican a
-     * posteriori sobre el conjunto de resultados.
+     * Por diseño no incluye paginación ni formato: ambos se aplican a posteriori
+     * sobre la lista completa de resultados que guarda el cache.
+     *
+     * <p>El delimitador se escapa dentro de cada valor: sin esto,
+     * {@code federal_entity="x|y"} colisionaría con
+     * {@code federal_entity="x", municipality="y"} y un request podría recibir
+     * la lista cacheada del otro.</p>
      */
     public String normalizedFilterCacheKey() {
         return String.join("|",
-                Util.normalizeCacheKey(federalEntity),
-                Util.normalizeCacheKey(municipality),
-                Util.normalizeCacheKey(settlement),
-                Util.normalizeCacheKey(settlementType),
-                Util.normalizeCacheKey(zoneType));
+                escapeDelimiter(Util.normalizeCacheKey(federalEntity)),
+                escapeDelimiter(Util.normalizeCacheKey(municipality)),
+                escapeDelimiter(Util.normalizeCacheKey(settlement)),
+                escapeDelimiter(Util.normalizeCacheKey(settlementType)),
+                escapeDelimiter(Util.normalizeCacheKey(zoneType)));
+    }
+
+    private static String escapeDelimiter(String value) {
+        return value.replace("\\", "\\\\").replace("|", "\\|");
     }
 
     /**
-     * Indica si el request tiene al menos un filtro útil. Usado por las
-     * condiciones SpEL de {@code @Cacheable} para evitar entrar al cache con
-     * requests inválidos que de todas formas terminarán en
-     * IllegalArgumentException (#19).
+     * Indica si el request tiene al menos un filtro útil. Es la validación que
+     * usa el servicio antes de tocar el cache: sin ningún filtro la búsqueda
+     * avanzada no tiene sentido y termina en IllegalArgumentException (#19).
      */
     public boolean hasAnyFilter() {
         return notBlank(federalEntity)

--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/SepomexZipCodeLoader.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/SepomexZipCodeLoader.java
@@ -22,13 +22,12 @@ import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 
@@ -106,9 +105,13 @@ public class SepomexZipCodeLoader {
         DigestInputStream digestStream = new DigestInputStream(bufferedStream, digest);
 
         // Estructuras temporales mutables: acumulan asentamientos por CP y canonizan
-        // los Strings repetidos. Ambas se descartan al terminar el parseo.
+        // los Strings repetidos. Todas se descartan al terminar el parseo.
+        // normalizedPool memoiza valor crudo -> valor normalizado canónico para los
+        // campos de baja cardinalidad, de modo que la normalización NFD corra una vez
+        // por valor distinto (decenas) y no una vez por línea (~1.5M).
         Map<String, Accumulator> accumulators = new HashMap<>();
         Map<String, String> stringPool = new HashMap<>();
+        Map<String, String> normalizedPool = new HashMap<>();
 
         try (BufferedReader reader = new BufferedReader(
                 new InputStreamReader(digestStream, charset))) {
@@ -118,7 +121,7 @@ public class SepomexZipCodeLoader {
             reader.readLine();
 
             long linesProcessed = reader.lines()
-                    .filter(line -> processLine(line, accumulators, stringPool))
+                    .filter(line -> processLine(line, accumulators, stringPool, normalizedPool))
                     .count();
 
             String checksum = HexFormat.of().formatHex(digest.digest());
@@ -142,8 +145,8 @@ public class SepomexZipCodeLoader {
     private ZipCodeData buildIndices(Map<String, Accumulator> accumulators, String checksum, String source) {
         Map<String, ZipCode> byCode = new HashMap<>(accumulators.size() * 2);
         NavigableMap<String, ZipCode> sorted = new TreeMap<>();
-        Map<String, Set<ZipCode>> byNormalizedEntity = new HashMap<>();
-        Map<String, Set<ZipCode>> byNormalizedMunicipality = new HashMap<>();
+        Map<String, List<ZipCode>> byNormalizedEntity = new HashMap<>();
+        Map<String, List<ZipCode>> byNormalizedMunicipality = new HashMap<>();
 
         for (Accumulator acc : accumulators.values()) {
             ZipCode zipCode = acc.toImmutable();
@@ -151,12 +154,26 @@ public class SepomexZipCodeLoader {
             byCode.put(zipCode.getZipCode(), zipCode);
             sorted.put(zipCode.getZipCode(), zipCode);
             byNormalizedEntity
-                    .computeIfAbsent(zipCode.getNormalizedFederalEntity(), k -> new HashSet<>())
+                    .computeIfAbsent(zipCode.getNormalizedFederalEntity(), k -> new ArrayList<>())
                     .add(zipCode);
             byNormalizedMunicipality
-                    .computeIfAbsent(zipCode.getNormalizedMunicipality(), k -> new HashSet<>())
+                    .computeIfAbsent(zipCode.getNormalizedMunicipality(), k -> new ArrayList<>())
                     .add(zipCode);
         }
+
+        // Los buckets se ordenan UNA vez aquí y se congelan: las búsquedas paginadas
+        // ya no re-ordenan por request. No hace falta dedup (antes HashSet) porque
+        // cada ZipCode tiene exactamente una entidad y un municipio normalizados,
+        // así que los buckets de un mismo índice son disjuntos.
+        Comparator<ZipCode> byZip = Comparator.comparing(ZipCode::getZipCode);
+        byNormalizedEntity.replaceAll((k, bucket) -> {
+            bucket.sort(byZip);
+            return List.copyOf(bucket);
+        });
+        byNormalizedMunicipality.replaceAll((k, bucket) -> {
+            bucket.sort(byZip);
+            return List.copyOf(bucket);
+        });
 
         return new ZipCodeData(byCode, sorted, byNormalizedEntity, byNormalizedMunicipality, checksum, source);
     }
@@ -241,7 +258,10 @@ public class SepomexZipCodeLoader {
         return StandardCharsets.ISO_8859_1;
     }
 
-    private boolean processLine(String line, Map<String, Accumulator> accumulators, Map<String, String> pool) {
+    private boolean processLine(String line,
+                                Map<String, Accumulator> accumulators,
+                                Map<String, String> pool,
+                                Map<String, String> normalizedPool) {
         try {
             String[] words = PIPE_PATTERN.split(line);
 
@@ -286,14 +306,15 @@ public class SepomexZipCodeLoader {
 
             // Fix #18: Settlements es un record inmutable con los campos normalizados precomputados.
             // El nombre del asentamiento es de alta cardinalidad y no se canoniza; el tipo de
-            // asentamiento y el tipo de zona sí (apenas unas decenas de valores distintos).
+            // asentamiento y el tipo de zona sí (apenas unas decenas de valores distintos), y su
+            // normalización se memoiza para no repetir NFD+regex en cada línea.
             acc.settlements.add(new Settlements(
                     settlementName,
                     canonical(zoneTypeVal, pool),
                     canonical(settlementTypeVal, pool),
                     Util.normalizeString(settlementName),
-                    canonical(Util.normalizeString(settlementTypeVal), pool),
-                    canonical(Util.normalizeString(zoneTypeVal), pool)));
+                    normalizedCanonical(settlementTypeVal, pool, normalizedPool),
+                    normalizedCanonical(zoneTypeVal, pool, normalizedPool)));
 
             return true;
 
@@ -314,6 +335,20 @@ public class SepomexZipCodeLoader {
             return null;
         }
         return pool.computeIfAbsent(value, k -> k);
+    }
+
+    /**
+     * Versión normalizada y canónica de un valor de baja cardinalidad. Memoiza
+     * crudo -> normalizado en {@code normalizedPool} para que la normalización
+     * NFD sólo se ejecute la primera vez que aparece cada valor distinto.
+     */
+    private static String normalizedCanonical(String value,
+                                              Map<String, String> pool,
+                                              Map<String, String> normalizedPool) {
+        if (value == null) {
+            return null;
+        }
+        return normalizedPool.computeIfAbsent(value, v -> canonical(Util.normalizeString(v), pool));
     }
 
     private MessageDigest newSha256() throws IOException {

--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeData.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeData.java
@@ -2,9 +2,9 @@ package com.coderalexis.CodigoPostalApi.service;
 
 import com.coderalexis.CodigoPostalApi.model.ZipCode;
 
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Set;
 
 /**
  * Resultado inmutable de la carga del catálogo SEPOMEX: las cuatro estructuras
@@ -15,8 +15,10 @@ import java.util.Set;
  * <ul>
  *   <li>{@code byCode} - lookup directo O(1) por código postal</li>
  *   <li>{@code sorted} - búsqueda por prefijo O(log n + k) vía {@code subMap()}</li>
- *   <li>{@code byNormalizedEntity} - índice invertido por entidad federativa normalizada</li>
- *   <li>{@code byNormalizedMunicipality} - índice invertido por municipio normalizado</li>
+ *   <li>{@code byNormalizedEntity} - índice invertido por entidad federativa normalizada;
+ *       cada bucket es una lista inmutable pre-ordenada por código postal</li>
+ *   <li>{@code byNormalizedMunicipality} - índice invertido por municipio normalizado,
+ *       con buckets igualmente pre-ordenados</li>
  * </ul>
  *
  * <p>Incluye además metadata de frescura: {@code checksum} (SHA-256 del archivo
@@ -26,8 +28,8 @@ import java.util.Set;
 public record ZipCodeData(
         Map<String, ZipCode> byCode,
         NavigableMap<String, ZipCode> sorted,
-        Map<String, Set<ZipCode>> byNormalizedEntity,
-        Map<String, Set<ZipCode>> byNormalizedMunicipality,
+        Map<String, List<ZipCode>> byNormalizedEntity,
+        Map<String, List<ZipCode>> byNormalizedMunicipality,
         String checksum,
         String source) {
 }

--- a/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/service/ZipCodeService.java
@@ -12,7 +12,9 @@ import com.coderalexis.CodigoPostalApi.util.PaginationSupport;
 import com.coderalexis.CodigoPostalApi.util.Util;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -25,7 +27,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -53,8 +54,9 @@ public class ZipCodeService {
     // happens-before con cualquier lectura posterior desde los hilos de request.
     private volatile Map<String, ZipCode> zipCodesByCode = Map.of();
     private volatile NavigableMap<String, ZipCode> zipCodesSorted = Collections.emptyNavigableMap();
-    private volatile Map<String, Set<ZipCode>> zipCodesByNormalizedEntity = Map.of();
-    private volatile Map<String, Set<ZipCode>> zipCodesByNormalizedMunicipality = Map.of();
+    // Buckets inmutables pre-ordenados por código postal (se ordenan una vez en el load).
+    private volatile Map<String, List<ZipCode>> zipCodesByNormalizedEntity = Map.of();
+    private volatile Map<String, List<ZipCode>> zipCodesByNormalizedMunicipality = Map.of();
 
     // Pre-computed statistics (immutable after load)
     private volatile ZipCodeStats cachedStats;
@@ -78,14 +80,60 @@ public class ZipCodeService {
             .recordStats()
             .build();
 
+    /**
+     * Cachés por término (no por página): guardan la lista COMPLETA ordenada de
+     * resultados para cada término normalizado, incluida la lista vacía
+     * (negative caching: un término inexistente no re-escanea el índice en cada
+     * request; la excepción 404 se lanza igual por request al leer del cache).
+     * La paginación se aplica después con subList, así que navegar páginas del
+     * mismo término no re-ordena ni re-escanea, y page/size dejan de formar
+     * parte de la clave (sin churn). {@code Caffeine.get(key, fn)} bloquea por
+     * clave, lo que además evita estampidas en claves frías. Igual que
+     * {@link #partialPrefixCache}, se usa Caffeine directo (no {@code @Cacheable})
+     * para evitar la trampa de self-invocation y poder cachear vacíos.
+     * Los valores son sólo referencias a ZipCodes compartidos (~8 bytes c/u).
+     */
+    private final Cache<String, List<ZipCode>> entitySearchCache = Caffeine.newBuilder()
+            .maximumSize(200)
+            .expireAfterAccess(30, TimeUnit.MINUTES)
+            .recordStats()
+            .build();
+
+    private final Cache<String, List<ZipCode>> municipalitySearchCache = Caffeine.newBuilder()
+            .maximumSize(200)
+            .expireAfterAccess(30, TimeUnit.MINUTES)
+            .recordStats()
+            .build();
+
+    /**
+     * Igual que los anteriores pero acotado por peso (suma de tamaños de lista)
+     * en vez de por entradas: el peor caso de la búsqueda avanzada (filtro sólo
+     * por asentamiento/tipo/zona) puede materializar ~145k referencias.
+     */
+    private final Cache<String, List<ZipCode>> advancedSearchCache = Caffeine.newBuilder()
+            .maximumWeight(500_000)
+            .weigher((String key, List<ZipCode> value) -> Math.max(1, value.size()))
+            .expireAfterAccess(15, TimeUnit.MINUTES)
+            .recordStats()
+            .build();
+
     private volatile boolean dataLoaded = false;
 
     private final MetricsConfiguration metricsConfiguration;
     private final SepomexZipCodeLoader loader;
 
-    public ZipCodeService(MetricsConfiguration metricsConfiguration, SepomexZipCodeLoader loader) {
+    public ZipCodeService(MetricsConfiguration metricsConfiguration,
+                          SepomexZipCodeLoader loader,
+                          MeterRegistry meterRegistry) {
         this.metricsConfiguration = metricsConfiguration;
         this.loader = loader;
+        // Las cachés manuales también se cosechan vía Micrometer (mismo trato que
+        // las regiones Spring en CacheConfiguration); antes partialPrefixCache
+        // pagaba recordStats() sin que nadie leyera las estadísticas.
+        CaffeineCacheMetrics.monitor(meterRegistry, partialPrefixCache, "partialPrefix");
+        CaffeineCacheMetrics.monitor(meterRegistry, entitySearchCache, "federalEntitySearch");
+        CaffeineCacheMetrics.monitor(meterRegistry, municipalitySearchCache, "municipalitySearch");
+        CaffeineCacheMetrics.monitor(meterRegistry, advancedSearchCache, "advancedSearch");
     }
 
     public boolean isDataLoaded() {
@@ -203,11 +251,10 @@ public class ZipCodeService {
     }
 
     /**
-     * Búsqueda paginada por entidad federativa. Fix #8: ordena el conjunto
-     * (vía índice invertido) y materializa sólo la página solicitada en vez
-     * de la lista completa.
+     * Búsqueda paginada por entidad federativa. La lista completa ordenada se
+     * resuelve/cachea por término en {@link #entitySearchCache} (incluidos los
+     * términos sin resultados) y aquí sólo se pagina con subList.
      */
-    @Cacheable(value = "federalEntitySearchPaged", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#searchTerm) + '_' + #page + '_' + #size")
     public PagedResponse<ZipCode> searchByFederalEntity(String searchTerm, int page, int size) {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
@@ -215,7 +262,8 @@ public class ZipCodeService {
             PaginationSupport.validatePagination(page, size);
             String normalizedSearchTerm = validateSearchTerm(searchTerm, "federal_entity");
 
-            Set<ZipCode> matches = findCandidatesInIndex(zipCodesByNormalizedEntity, normalizedSearchTerm);
+            List<ZipCode> matches = entitySearchCache.get(normalizedSearchTerm,
+                    term -> findMatchesSorted(zipCodesByNormalizedEntity, term));
             if (matches.isEmpty()) {
                 metricsConfiguration.recordSearchError("federal_entity", "not_found");
                 throw new ZipCodeNotFoundException(
@@ -223,11 +271,7 @@ public class ZipCodeService {
                 );
             }
 
-            PagedResponse<ZipCode> response = PaginationSupport.paginateSorted(
-                    matches,
-                    Comparator.comparing(ZipCode::getZipCode),
-                    page,
-                    size);
+            PagedResponse<ZipCode> response = PaginationSupport.paginate(matches, page, size);
 
             metricsConfiguration.recordResultSize("federal_entity", (int) response.getTotalElements());
             return response;
@@ -237,9 +281,9 @@ public class ZipCodeService {
     }
 
     /**
-     * Búsqueda paginada por municipio. Fix #8: idem entidad federativa.
+     * Búsqueda paginada por municipio. Ídem entidad federativa: lista completa
+     * cacheada por término en {@link #municipalitySearchCache}, paginación con subList.
      */
-    @Cacheable(value = "municipalitySearchPaged", key = "T(com.coderalexis.CodigoPostalApi.util.Util).normalizeCacheKey(#searchTerm) + '_' + #page + '_' + #size")
     public PagedResponse<ZipCode> searchByMunicipality(String searchTerm, int page, int size) {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
@@ -247,7 +291,8 @@ public class ZipCodeService {
             PaginationSupport.validatePagination(page, size);
             String normalizedSearchTerm = validateSearchTerm(searchTerm, "municipality");
 
-            Set<ZipCode> matches = findCandidatesInIndex(zipCodesByNormalizedMunicipality, normalizedSearchTerm);
+            List<ZipCode> matches = municipalitySearchCache.get(normalizedSearchTerm,
+                    term -> findMatchesSorted(zipCodesByNormalizedMunicipality, term));
             if (matches.isEmpty()) {
                 metricsConfiguration.recordSearchError("municipality", "not_found");
                 throw new ZipCodeNotFoundException(
@@ -255,11 +300,7 @@ public class ZipCodeService {
                 );
             }
 
-            PagedResponse<ZipCode> response = PaginationSupport.paginateSorted(
-                    matches,
-                    Comparator.comparing(ZipCode::getZipCode),
-                    page,
-                    size);
+            PagedResponse<ZipCode> response = PaginationSupport.paginate(matches, page, size);
 
             metricsConfiguration.recordResultSize("municipality", (int) response.getTotalElements());
             return response;
@@ -408,31 +449,28 @@ public class ZipCodeService {
     }
 
     /**
-     * Paginated advanced search that materializes only the requested page.
-     * This keeps broad advanced searches from allocating all matching ZipCode
-     * objects when clients only need one page.
+     * Búsqueda avanzada paginada. La lista filtrada completa (ordenada por CP)
+     * se computa UNA vez por combinación de filtros y se cachea en
+     * {@link #advancedSearchCache} — incluido el peor caso (filtro sólo por
+     * asentamiento/tipo/zona, que escanea el catálogo completo) y las
+     * combinaciones sin resultados. Las páginas siguientes son un subList.
      */
-    @Cacheable(
-            value = "advancedSearchPaged",
-            key = "#request.normalizedFilterCacheKey() + '_' + #page + '_' + #size",
-            condition = "#request != null && #request.hasAnyFilter() && #page >= 0 && #size > 0")
     public PagedResponse<ZipCode> advancedSearch(AdvancedSearchRequest request, int page, int size) {
         Timer.Sample sample = metricsConfiguration.startTimer();
         try {
             PaginationSupport.validatePagination(page, size);
             AdvancedSearchCriteria criteria = validateAndNormalizeAdvancedSearchRequest(request);
-            Collection<ZipCode> candidates = resolveOrderedSearchCandidates(criteria);
 
-            PagedResponse<ZipCode> response = PaginationSupport.paginateFiltered(
-                    candidates,
-                    zipCode -> matchesAdvancedCriteria(zipCode, criteria),
-                    page,
-                    size);
+            List<ZipCode> results = advancedSearchCache.get(
+                    request.normalizedFilterCacheKey(),
+                    key -> computeAdvancedResults(criteria));
 
-            if (response.getTotalElements() == 0) {
+            if (results.isEmpty()) {
                 metricsConfiguration.recordSearchError("advanced", "not_found");
                 throw new ZipCodeNotFoundException("No se encontraron codigos postales con los criterios especificados");
             }
+
+            PagedResponse<ZipCode> response = PaginationSupport.paginate(results, page, size);
 
             metricsConfiguration.recordResultSize("advanced", (int) response.getTotalElements());
             return response;
@@ -441,17 +479,28 @@ public class ZipCodeService {
         }
     }
 
-    private AdvancedSearchCriteria validateAndNormalizeAdvancedSearchRequest(AdvancedSearchRequest request) {
-        if (request == null) {
-            metricsConfiguration.recordSearchError("advanced", "empty_search");
-            throw new IllegalArgumentException("Debe proporcionar al menos un criterio de busqueda");
+    /**
+     * Materializa la lista completa (en orden de código postal) que satisface
+     * los criterios. Todos los orígenes de candidatos ya vienen ordenados
+     * (buckets pre-ordenados del índice o {@code zipCodesSorted.values()}),
+     * así que el filtrado preserva el orden sin re-sort.
+     */
+    private List<ZipCode> computeAdvancedResults(AdvancedSearchCriteria criteria) {
+        Collection<ZipCode> candidates = resolveSearchCandidates(
+                criteria.normalizedEntity(),
+                criteria.normalizedMunicipality());
+
+        if (candidates.isEmpty()) {
+            return List.of();
         }
 
-        if ((request.getFederalEntity() == null || request.getFederalEntity().isBlank()) &&
-            (request.getMunicipality() == null || request.getMunicipality().isBlank()) &&
-            (request.getSettlement() == null || request.getSettlement().isBlank()) &&
-            (request.getSettlementType() == null || request.getSettlementType().isBlank()) &&
-            (request.getZoneType() == null || request.getZoneType().isBlank())) {
+        return candidates.stream()
+                .filter(zipCode -> matchesAdvancedCriteria(zipCode, criteria))
+                .toList();
+    }
+
+    private AdvancedSearchCriteria validateAndNormalizeAdvancedSearchRequest(AdvancedSearchRequest request) {
+        if (request == null || !request.hasAnyFilter()) {
             metricsConfiguration.recordSearchError("advanced", "empty_search");
             throw new IllegalArgumentException("Debe proporcionar al menos un criterio de busqueda");
         }
@@ -462,24 +511,6 @@ public class ZipCodeService {
                 request.getSettlement() != null ? Util.normalizeSearchTerm(request.getSettlement()) : null,
                 request.getSettlementType() != null ? Util.normalizeSearchTerm(request.getSettlementType()) : null,
                 request.getZoneType() != null ? Util.normalizeSearchTerm(request.getZoneType()) : null);
-    }
-
-    private Collection<ZipCode> resolveOrderedSearchCandidates(AdvancedSearchCriteria criteria) {
-        Collection<ZipCode> candidates = resolveSearchCandidates(
-                criteria.normalizedEntity(),
-                criteria.normalizedMunicipality());
-
-        if (candidates.isEmpty()) {
-            return List.of();
-        }
-
-        if (candidates instanceof Set<?>) {
-            return candidates.stream()
-                    .sorted(Comparator.comparing(ZipCode::getZipCode))
-                    .toList();
-        }
-
-        return candidates;
     }
 
     /**
@@ -543,12 +574,12 @@ public class ZipCodeService {
     }
 
     private Collection<ZipCode> resolveSearchCandidates(String normalizedEntity, String normalizedMunicipality) {
-        Set<ZipCode> entityCandidates = findCandidatesInIndex(zipCodesByNormalizedEntity, normalizedEntity);
+        List<ZipCode> entityCandidates = findMatchesSorted(zipCodesByNormalizedEntity, normalizedEntity);
         if (isFilterPresent(normalizedEntity) && entityCandidates.isEmpty()) {
             return List.of();
         }
 
-        Set<ZipCode> municipalityCandidates = findCandidatesInIndex(
+        List<ZipCode> municipalityCandidates = findMatchesSorted(
                 zipCodesByNormalizedMunicipality, normalizedMunicipality);
         if (isFilterPresent(normalizedMunicipality) && municipalityCandidates.isEmpty()) {
             return List.of();
@@ -572,16 +603,41 @@ public class ZipCodeService {
         return zipCodesSorted.values();
     }
 
-    private Set<ZipCode> findCandidatesInIndex(Map<String, Set<ZipCode>> index, String normalizedSearchTerm) {
+    /**
+     * Devuelve, en orden de código postal, los ZipCodes de todas las claves del
+     * índice que contienen el término. Los buckets del índice son disjuntos
+     * (cada ZipCode tiene una sola entidad/municipio) y vienen pre-ordenados
+     * del load, así que el caso común de una sola clave coincidente devuelve el
+     * bucket tal cual, sin copia ni sort; sólo la unión de varias claves ordena.
+     */
+    private List<ZipCode> findMatchesSorted(Map<String, List<ZipCode>> index, String normalizedSearchTerm) {
         if (!isFilterPresent(normalizedSearchTerm)) {
-            return Set.of();
+            return List.of();
         }
 
-        Set<ZipCode> candidates = new HashSet<>();
-        index.entrySet().stream()
-                .filter(entry -> entry.getKey().contains(normalizedSearchTerm))
-                .forEach(entry -> candidates.addAll(entry.getValue()));
-        return candidates;
+        List<ZipCode> single = null;
+        List<ZipCode> merged = null;
+        for (Map.Entry<String, List<ZipCode>> entry : index.entrySet()) {
+            if (!entry.getKey().contains(normalizedSearchTerm)) {
+                continue;
+            }
+            if (merged != null) {
+                merged.addAll(entry.getValue());
+            } else if (single == null) {
+                single = entry.getValue();
+            } else {
+                merged = new ArrayList<>(single.size() + entry.getValue().size());
+                merged.addAll(single);
+                merged.addAll(entry.getValue());
+                single = null;
+            }
+        }
+
+        if (merged != null) {
+            merged.sort(Comparator.comparing(ZipCode::getZipCode));
+            return List.copyOf(merged);
+        }
+        return single != null ? single : List.of();
     }
 
     private boolean isFilterPresent(String normalizedSearchTerm) {

--- a/src/main/java/com/coderalexis/CodigoPostalApi/util/PaginationSupport.java
+++ b/src/main/java/com/coderalexis/CodigoPostalApi/util/PaginationSupport.java
@@ -2,20 +2,15 @@ package com.coderalexis.CodigoPostalApi.util;
 
 import com.coderalexis.CodigoPostalApi.model.PagedResponse;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
-import java.util.function.Predicate;
 
 /**
  * Utilidades genéricas de paginación, extraídas de {@code ZipCodeService} (#10)
  * para separar la mecánica de paginación de la lógica de negocio y poder
  * reutilizarlas/probarlas de forma aislada.
  *
- * <p>Todas las variantes usan aritmética en {@code long} para el offset, de modo
- * que {@code page * size} no desborde {@link Integer#MAX_VALUE}.</p>
+ * <p>Se usa aritmética en {@code long} para el offset, de modo que
+ * {@code page * size} no desborde {@link Integer#MAX_VALUE}.</p>
  */
 public final class PaginationSupport {
 
@@ -39,70 +34,6 @@ public final class PaginationSupport {
         int start = (int) offset; // Safe: offset < totalElements which is an int
         int end = Math.min(start + size, totalElements);
         return buildPagedResponse(allResults.subList(start, end), page, size, totalElements, totalPages);
-    }
-
-    /**
-     * Ordena el conjunto candidato con el comparador dado y materializa
-     * únicamente la página solicitada.
-     */
-    public static <T> PagedResponse<T> paginateSorted(
-            Set<T> candidates,
-            Comparator<T> comparator,
-            int page,
-            int size) {
-        validatePagination(page, size);
-
-        int totalElements = candidates.size();
-        int totalPages = calculateTotalPages(totalElements, size);
-        long offset = (long) page * size;
-
-        if (offset >= totalElements) {
-            return buildPagedResponse(List.of(), page, size, totalElements, totalPages);
-        }
-
-        int start = (int) offset;
-        int limit = Math.min(size, totalElements - start);
-        List<T> pageContent = candidates.stream()
-                .sorted(comparator)
-                .skip(start)
-                .limit(limit)
-                .toList();
-
-        return buildPagedResponse(pageContent, page, size, totalElements, totalPages);
-    }
-
-    /**
-     * Pagina una colección aplicando un filtro al vuelo, sin materializar el
-     * conjunto filtrado completo. Se preserva el orden de iteración de la colección.
-     */
-    public static <T> PagedResponse<T> paginateFiltered(
-            Collection<T> candidates,
-            Predicate<T> filter,
-            int page,
-            int size) {
-        validatePagination(page, size);
-
-        long offset = (long) page * size;
-        List<T> pageContent = new ArrayList<>(size);
-        int totalElements = 0;
-
-        for (T candidate : candidates) {
-            if (!filter.test(candidate)) {
-                continue;
-            }
-
-            if (totalElements >= offset && pageContent.size() < size) {
-                pageContent.add(candidate);
-            }
-            totalElements++;
-        }
-
-        return buildPagedResponse(
-                pageContent,
-                page,
-                size,
-                totalElements,
-                calculateTotalPages(totalElements, size));
     }
 
     public static void validatePagination(int page, int size) {

--- a/src/main/resources/application-railway.yml
+++ b/src/main/resources/application-railway.yml
@@ -38,12 +38,16 @@ ratelimit:
   ip-based: true
   burst-capacity: 15
 
-# Actuator - solo health y prometheus en el mismo puerto
+# Actuator: Railway sirve UN solo puerto público, así que todo lo expuesto aquí
+# queda accesible desde internet sin autenticación. Por defecto sólo health
+# (necesario para el healthcheck de Railway); /actuator/prometheus quedaba
+# público sin auth. Si se scrapea vía red privada de Railway, restaurar con la
+# variable de entorno ACTUATOR_EXPOSURE=health,prometheus,info
 management:
   endpoints:
     web:
       exposure:
-        include: health,prometheus,info
+        include: ${ACTUATOR_EXPOSURE:health}
   endpoint:
     health:
       show-details: never

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,7 +85,9 @@ management:
       export:
         enabled: true
 
-# Configuración de Rate Limiting por defecto (se sobrescribe en cada perfil)
+# Configuración de Rate Limiting por defecto (se sobrescribe en cada perfil).
+# burst-capacity no configurada => capacidad efectiva = requests-per-minute
+# (ver RateLimitProperties.getEffectiveBurstCapacity).
 ratelimit:
   enabled: false
   requests-per-minute: 1000

--- a/src/test/java/com/coderalexis/CodigoPostalApi/config/RateLimitInterceptorTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/config/RateLimitInterceptorTest.java
@@ -115,6 +115,36 @@ class RateLimitInterceptorTest {
     }
 
     @Test
+    @DisplayName("Burst no configurado: la capacidad efectiva es requests-per-minute")
+    void shouldDefaultBurstToRequestsPerMinute() throws Exception {
+        RateLimitProperties props = new RateLimitProperties();
+        props.setEnabled(true);
+        props.setRequestsPerMinute(3);
+        // burstCapacity se queda en 0 = "no configurado"
+        assertEquals(3, props.getEffectiveBurstCapacity(),
+                "Sin burst configurado, la capacidad debe igualar la tasa por minuto");
+
+        RateLimitInterceptor limited = new RateLimitInterceptor(props);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/zip-codes/01000");
+        request.setRemoteAddr("198.51.100.20");
+
+        // Las 3 primeras pasan (capacidad efectiva = 3, no el viejo default de 20... ni 0).
+        for (int i = 0; i < 3; i++) {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            assertTrue(limited.preHandle(request, response, new Object()),
+                    "Las peticiones dentro de la capacidad efectiva deben pasar (iteración " + i + ")");
+            assertEquals("3", response.getHeader("X-RateLimit-Burst"),
+                    "El header X-RateLimit-Burst debe exponer la capacidad real del bucket");
+        }
+
+        // La cuarta excede la capacidad → 429 y también lleva el header Burst.
+        MockHttpServletResponse blocked = new MockHttpServletResponse();
+        assertFalse(limited.preHandle(request, blocked, new Object()));
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), blocked.getStatus());
+        assertEquals("3", blocked.getHeader("X-RateLimit-Burst"));
+    }
+
+    @Test
     @DisplayName("preHandle aísla buckets entre IPs cuando ip-based=true")
     void shouldIsolateBucketsBetweenClients() throws Exception {
         RateLimitProperties props = new RateLimitProperties();

--- a/src/test/java/com/coderalexis/CodigoPostalApi/controller/ControllerTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/controller/ControllerTest.java
@@ -11,8 +11,13 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import org.springframework.test.web.servlet.MvcResult;
+
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -411,5 +416,85 @@ class ControllerTest {
         mockMvc.perform(get("/actuator/health/readiness"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("UP"));
+    }
+
+    // ============================================================
+    // Manejo de errores HTTP: parámetro faltante, tipo inválido, 405
+    // ============================================================
+
+    @Test
+    @DisplayName("GET /zip-codes sin federal_entity - Debe retornar 400 (no 500)")
+    void shouldReturn400ForMissingRequiredParameter() throws Exception {
+        mockMvc.perform(get("/zip-codes")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message", containsString("Falta el parámetro requerido: federal_entity")))
+                .andExpect(jsonPath("$.path", containsString("/zip-codes")));
+    }
+
+    @Test
+    @DisplayName("GET /zip-codes?page=abc - Debe retornar 400 por tipo inválido")
+    void shouldReturn400ForTypeMismatch() throws Exception {
+        mockMvc.perform(get("/zip-codes")
+                .param("federal_entity", "Jalisco")
+                .param("page", "abc")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message", containsString("Valor inválido para el parámetro 'page'")));
+    }
+
+    @Test
+    @DisplayName("POST /zip-codes/stats - Debe retornar 405 con header Allow")
+    void shouldReturn405ForUnsupportedMethod() throws Exception {
+        mockMvc.perform(post("/zip-codes/stats")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(header().exists("Allow"))
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.message", containsString("no soportado")));
+    }
+
+    @Test
+    @DisplayName("Errores de validación: message describe el error y path contiene la URI")
+    void shouldPutValidationErrorsInMessageAndUriInPath() throws Exception {
+        mockMvc.perform(get("/zip-codes")
+                .param("federal_entity", "méxico")
+                .param("size", "150")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", containsString("Errores de validación")))
+                .andExpect(jsonPath("$.path", containsString("/zip-codes")));
+    }
+
+    // ============================================================
+    // ETag versionado por catálogo / 304 Not Modified
+    // ============================================================
+
+    @Test
+    @DisplayName("Las respuestas GET deben llevar ETag y honrar If-None-Match con 304")
+    void shouldReturnEtagAndHonorIfNoneMatch() throws Exception {
+        MvcResult result = mockMvc.perform(get("/zip-codes/01000")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("ETag"))
+                .andReturn();
+
+        String etag = result.getResponse().getHeader("ETag");
+        assertNotNull(etag);
+        assertTrue(etag.startsWith("W/\""), "El ETag debe ser débil (W/) por la compresión");
+
+        // Mismo validador -> 304 sin cuerpo (la búsqueda ni siquiera se ejecuta).
+        mockMvc.perform(get("/zip-codes/01000")
+                .header("If-None-Match", etag))
+                .andExpect(status().isNotModified())
+                .andExpect(content().string(""));
+
+        // Validador de otra versión del catálogo -> respuesta completa.
+        mockMvc.perform(get("/zip-codes/01000")
+                .header("If-None-Match", "W/\"otro-catalogo-0\""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.zip_code").value("01000"));
     }
 }

--- a/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
+++ b/src/test/java/com/coderalexis/CodigoPostalApi/service/ZipCodeServiceTest.java
@@ -5,6 +5,7 @@ import com.coderalexis.CodigoPostalApi.model.AdvancedSearchRequest;
 import com.coderalexis.CodigoPostalApi.model.PagedResponse;
 import com.coderalexis.CodigoPostalApi.model.ZipCode;
 import com.coderalexis.CodigoPostalApi.model.ZipCodeStats;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +22,9 @@ class ZipCodeServiceTest {
 
     @Autowired
     private ZipCodeService zipCodeService;
+
+    @Autowired
+    private MeterRegistry meterRegistry;
 
     @Test
     @DisplayName("Debe cargar los datos al iniciar")
@@ -270,6 +274,23 @@ class ZipCodeServiceTest {
     }
 
     @Test
+    @DisplayName("La llave de cache avanzada no debe colisionar cuando un filtro contiene el delimitador")
+    void shouldNotCollideAdvancedCacheKeysWhenFilterContainsDelimiter() {
+        AdvancedSearchRequest pipeInsideOneFilter = AdvancedSearchRequest.builder()
+                .federalEntity("x|y")
+                .build();
+
+        AdvancedSearchRequest twoSeparateFilters = AdvancedSearchRequest.builder()
+                .federalEntity("x")
+                .municipality("y")
+                .build();
+
+        assertNotEquals(pipeInsideOneFilter.normalizedFilterCacheKey(),
+                twoSeparateFilters.normalizedFilterCacheKey(),
+            "Un '|' dentro de un filtro no debe producir la misma llave que dos filtros separados");
+    }
+
+    @Test
     @DisplayName("Debe paginar búsqueda avanzada sin materializar desde el controlador")
     void shouldPaginateAdvancedSearchInService() {
         AdvancedSearchRequest request = AdvancedSearchRequest.builder()
@@ -322,6 +343,83 @@ class ZipCodeServiceTest {
         assertTrue(content.size() >= 2, "Se necesitan al menos 2 CP de la misma entidad");
         assertSame(content.get(0).getFederalEntity(), content.get(1).getFederalEntity(),
             "Los CP de la misma entidad deben compartir la instancia canónica de federalEntity");
+    }
+
+    @Test
+    @DisplayName("Debe cachear términos sin resultados (negative caching) y seguir lanzando 404")
+    void shouldCacheNotFoundEntityResults() {
+        String term = "EntidadInexistenteNegCache";
+
+        assertThrows(ZipCodeNotFoundException.class,
+                () -> zipCodeService.searchByFederalEntity(term, 0, 20),
+                "La primera búsqueda debe lanzar ZipCodeNotFoundException");
+
+        double hitsBefore = cacheHits("federalEntitySearch");
+        assertThrows(ZipCodeNotFoundException.class,
+                () -> zipCodeService.searchByFederalEntity(term, 0, 20),
+                "La segunda búsqueda debe seguir lanzando ZipCodeNotFoundException");
+        double hitsAfter = cacheHits("federalEntitySearch");
+
+        assertTrue(hitsAfter > hitsBefore,
+                "La segunda búsqueda del mismo término inexistente debe servirse desde la caché");
+    }
+
+    @Test
+    @DisplayName("Debe mantener páginas disjuntas y orden global entre páginas del mismo término")
+    void shouldKeepPagesDisjointAndGloballySorted() {
+        PagedResponse<ZipCode> page0 = zipCodeService.searchByFederalEntity("Jalisco", 0, 5);
+        PagedResponse<ZipCode> page1 = zipCodeService.searchByFederalEntity("Jalisco", 1, 5);
+
+        assertEquals(page0.getTotalElements(), page1.getTotalElements(),
+                "El total debe ser idéntico entre páginas del mismo término");
+
+        List<String> codes0 = page0.getContent().stream().map(ZipCode::getZipCode).toList();
+        List<String> codes1 = page1.getContent().stream().map(ZipCode::getZipCode).toList();
+        assertFalse(codes1.isEmpty(), "Jalisco debe tener más de una página con size=5");
+
+        assertTrue(codes0.stream().noneMatch(codes1::contains), "Las páginas deben ser disjuntas");
+        assertEquals(codes0.stream().sorted().toList(), codes0, "La página debe venir ordenada por CP");
+        assertTrue(codes0.get(codes0.size() - 1).compareTo(codes1.get(0)) < 0,
+                "El último CP de la página 0 debe ser menor que el primero de la página 1");
+    }
+
+    @Test
+    @DisplayName("Debe cachear la búsqueda avanzada solo-asentamiento y servir páginas siguientes desde caché")
+    void shouldCacheAdvancedSearchBySettlementTypeOnly() {
+        AdvancedSearchRequest request = AdvancedSearchRequest.builder()
+                .settlementType("Colonia")
+                .build();
+
+        PagedResponse<ZipCode> first = zipCodeService.advancedSearch(request, 0, 10);
+        assertTrue(first.getTotalElements() > 0, "Debe haber CP con asentamientos tipo Colonia");
+
+        double hitsBefore = cacheHits("advancedSearch");
+        PagedResponse<ZipCode> second = zipCodeService.advancedSearch(request, 1, 10);
+        double hitsAfter = cacheHits("advancedSearch");
+
+        assertTrue(hitsAfter > hitsBefore,
+                "La página siguiente de la misma combinación de filtros debe ser un hit de caché");
+        assertEquals(first.getTotalElements(), second.getTotalElements());
+    }
+
+    @Test
+    @DisplayName("Debe cachear combinaciones avanzadas sin resultados y seguir lanzando 404")
+    void shouldStillThrowForCachedEmptyAdvancedSearch() {
+        AdvancedSearchRequest request = AdvancedSearchRequest.builder()
+                .settlement("AsentamientoInexistente12345XYZ")
+                .build();
+
+        assertThrows(ZipCodeNotFoundException.class, () -> zipCodeService.advancedSearch(request, 0, 10));
+        assertThrows(ZipCodeNotFoundException.class, () -> zipCodeService.advancedSearch(request, 0, 10),
+                "La combinación vacía cacheada debe seguir produciendo 404 por request");
+    }
+
+    private double cacheHits(String cacheName) {
+        return meterRegistry.get("cache.gets")
+                .tag("cache", cacheName)
+                .tag("result", "hit")
+                .functionCounter()
+                .count();
     }
 
 }


### PR DESCRIPTION
## Resumen

Ronda de optimización y endurecimiento en 4 frentes: rendimiento hot-path, robustez de API, HTTP caching/seguridad y build/despliegue. Todo verificado contra servidor y contenedor reales, no solo con la suite de tests.

## Rendimiento hot-path

- **Índices invertidos pre-ordenados**: cada bucket entidad/municipio se ordena una vez al cargar y queda inmutable — las búsquedas paginadas ya no re-ordenan el set completo en cada request.
- **Cachés por término (no por página)**: guardan la lista completa ordenada; la paginación es un `subList`. Esto elimina de una vez: el re-sort por página, el churn de claves por `page`/`size`, las estampidas en claves frías (bloqueo por clave de Caffeine) y añade **negative caching** (términos inexistentes cacheados — el 404 se sigue lanzando por request).
- **Búsqueda avanzada de peor caso** (filtro solo-asentamiento, escanea ~145k): se computa una vez por combinación de filtros. Medido: 11–69ms el miss frío vs 1.7–7ms el hit (**hasta 13x**); antes cada página nueva pagaba el miss.
- **Loader**: la normalización NFD de tipos de asentamiento/zona pasa de ~1.5M ejecuciones a unas decenas (memoizada por valor distinto).
- Región de caché muerta `zipcodes` eliminada; las 4 cachés manuales ahora reportan métricas a Prometheus (`cache_gets_total{cache="federalEntitySearch"}`, etc.).

## Robustez de API

- Parámetro requerido faltante → **400** (antes 500); tipo inválido (`page=abc`) → **400**; método no soportado → **405** con header `Allow`.
- `ErrorResponse.path` siempre es la URI del request; `message` describe el error (antes los handlers de validación los invertían).
- Nuevo header `X-RateLimit-Burst`; `burst-capacity` sin configurar ahora equivale a `requests-per-minute` (antes un default silencioso de 20 contradecía el `X-RateLimit-Limit` anunciado).

## HTTP caching y seguridad

- **ETag débil versionado por catálogo** (`W/"<checksum16>-<versión>"`): `If-None-Match` responde `304` desde `preHandle`, sin ejecutar búsqueda ni serialización (0.61ms vs 1.40ms medido).
- **Fix de bug pre-existente**: `Cache-Control` nunca llegaba al cliente en respuestas con body — `afterCompletion` corría después de que el flush de Jackson comprometiera la respuesta. Ahora se aplica vía `ResponseBodyAdvice` (los tests MockMvc no lo detectaban porque `MockHttpServletResponse` nunca se compromete).
- La llave de caché avanzada escapa el delimitador: `federal_entity="x|y"` ya no colisiona con `federal_entity="x", municipality="y"`.

## Build y despliegue

- **JaCoCo** cableado (`mvn verify` → `target/site/jacoco/`; el README ya lo documentaba pero el plugin no existía). CI sube cobertura y construye la imagen Docker en cada push/PR.
- **Dockerfile**: jar extraído (`jarmode=tools`) + **training run CDS en build** — medido ~1.1s menos de arranque (3.39s vs 4.75s de media, muestras alternadas). Spring AOT evaluado y descartado (congelaría la selección de perfiles en build-time). Eliminados los flags obsoletos `-XX:+ZGenerational` (aborta el arranque en JDK 25) y `-XX:+UseContainerSupport`.
- **Fixes de contenedor encontrados en verificación real**:
  - El healthcheck fallaba permanentemente en perfil prod (actuator en 9090, el check sondeaba `$PORT`) — un orquestador habría reiniciado el contenedor en bucle. Ahora sondea `MANAGEMENT_PORT` con fallback a 9090; verificado `healthy` en prod.
  - `/var/log/codigopostal-api` pre-creado (Logback fallaba con `FileNotFoundException` en cada arranque prod).
  - `railway.toml` actualizado al layout extraído — su `startCommand` apuntaba a `/app/app.jar`, que ya no existe, y omitía los flags de GC que el archive CDS exige.

## ⚠️ Cambios de comportamiento observable

1. **Nombres de métricas de caché**: `federalEntitySearchPaged` → `federalEntitySearch`, `municipalitySearchPaged` → `municipalitySearch`, `advancedSearchPaged` → `advancedSearch`, más `partialPrefix` nuevo. Dashboards de Grafana que referencien los nombres viejos deben actualizarse.
2. **Railway**: `/actuator/prometheus` e `/info` dejan de exponerse públicamente por defecto (quedaban en el `$PORT` público sin auth). Restaurar con `ACTUATOR_EXPOSURE=health,prometheus,info` si se scrapea vía red privada.
3. Perfiles sin `burst-capacity` explícito (base/dev) ahora permiten ráfagas hasta `requests-per-minute` en vez de 20.

## Verificación

- **81 tests en verde** (11 nuevos: negative caching con hit de caché vía MeterRegistry, consistencia entre páginas, colisión de llaves, 400/405, suite ETag/304, burst efectivo). Cobertura: 88% instrucciones / 71% ramas.
- Smoke test contra servidor real: ETag/304, `Cache-Control` en 200 y ausente en errores, 400/405, métricas en `/actuator/prometheus`.
- Imagen Docker construida y arrancada en perfil prod: archive CDS mapeado (`-Xlog:cds`), contenedor `healthy`, sin errores de Logback; benchmark de arranque con/sin CDS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
